### PR TITLE
Stop the flashing instructions erasing the chip on a failed transfer

### DIFF
--- a/app/helpers/installation_helper.rb
+++ b/app/helpers/installation_helper.rb
@@ -9,6 +9,40 @@ module InstallationHelper
     content_tag 'span', '# Enter commands line by line! Do not copy and paste multiple lines at once!', class: 'text-danger'
   end
 
+  # `sf probe` has to run before any erase, and `sf lock 0` clears the status
+  # register block protection some vendors arm. Kept as its own line rather
+  # than chained into the flashing command: plenty of vendor U-Boots have no
+  # `sf lock` subcommand at all, and a chain would abort on their error
+  # instead of going on to flash.
+  def unlock_flash(text, c)
+    text << 'sf probe 0; sf lock 0;' unless c.flash_type.eql?('nand')
+  end
+
+  # Build one line that only erases if the transfer before it succeeded.
+  #
+  # Both halves matter. U-Boot's `&&` stops a failed `tftpboot`/`tftp`/
+  # `fatload` from reaching the erase, and `${filesize}` bounds the write to
+  # what actually arrived. Without them a transfer that fails, or one whose
+  # load address was mistyped -- U-Boot's hex parser stops at the first
+  # non-hex character, so `0mx82000000` silently becomes `0` -- still erased
+  # the chip and wrote back the `mw.b` fill, putting 0xff over the
+  # bootloader while reporting success. See OpenIPC/website#55 and the
+  # camera it destroyed in OpenIPC/firmware#2299.
+  #
+  # It must stay a single line, because the block above it tells the user to
+  # enter commands one at a time.
+  def guarded_flash(c, transfer, offset, erase_size, write_size)
+    cmd = c.flash_type.eql?('nand') ? 'nand' : 'sf'
+    "#{transfer} && #{cmd} erase #{offset} #{erase_size} " \
+      "&& #{cmd} write #{c.soc.load_address} #{offset} #{write_size}"
+  end
+
+  # NOR writes only what arrived. NAND keeps the fixed partition size it has
+  # always used, since `${filesize}` is not guaranteed to be page-aligned.
+  def write_size_for(c, fixed)
+    c.flash_type.eql?('nand') ? fixed : '${filesize}'
+  end
+
   def firmware_backup(c)
     text = []
     text << do_not_copy_paste
@@ -31,6 +65,7 @@ module InstallationHelper
     else
       text << "tftpput #{c.soc.load_address} #{c.flash_size_hex} #{c.backup_filename}"
       text << '# if there is no tftpput but tftp then run this instead'
+      text << '# (the third argument is what makes tftp upload rather than download)'
       text << "tftp #{c.soc.load_address} #{c.backup_filename} #{c.flash_size_hex}"
     end
     list_of_commands text
@@ -38,46 +73,44 @@ module InstallationHelper
 
   def flashing_everything(c)
     fw_filename = "openipc-#{c.soc.model_downcase}-#{c.firmware_version}-#{c.flash_size}mb.bin"
+    write_size = write_size_for(c, c.flash_size_hex)
     text = []
     text << do_not_copy_paste
     text << "setenv ipaddr #{c.camera_ip_address}; setenv serverip #{c.server_ip_address}"
     text << "mw.b #{c.soc.load_address} 0xff #{c.flash_size_hex}"
+    unlock_flash text, c
     if c.sd_card_slot.eql?('sd') && c.network_interface.eql?('wifi')
-      text << "fatload mmc 0:1 #{c.soc.load_address} #{fw_filename}"
+      text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{fw_filename}",
+                            '0x0', c.flash_size_hex, write_size)
     else
-      text << "tftpboot #{c.soc.load_address} #{fw_filename}"
+      text << guarded_flash(c, "tftpboot #{c.soc.load_address} #{fw_filename}",
+                            '0x0', c.flash_size_hex, write_size)
       text << '# if there is no tftpboot but tftp then run this instead'
-      text << "tftp #{c.soc.load_address} #{fw_filename}"
-    end
-    if c.flash_type.eql?('nand')
-      text << "nand erase 0x0 #{c.flash_size_hex}; nand write #{c.soc.load_address} 0x0 #{c.flash_size_hex}"
-    else
-      text << 'sf probe 0; sf lock 0;'
-      text << "sf erase 0x0 #{c.flash_size_hex}; sf write #{c.soc.load_address} 0x0 #{c.flash_size_hex}"
+      text << guarded_flash(c, "tftp #{c.soc.load_address} #{fw_filename}",
+                            '0x0', c.flash_size_hex, write_size)
     end
     text << 'reset'
     list_of_commands text
   end
 
   def flashing_uboot(c)
+    write_size = write_size_for(c, '0x50000')
     text = []
     text << do_not_copy_paste
     unless c.network_interface.eql?('wifi')
       text << "setenv ipaddr #{c.camera_ip_address}; setenv serverip #{c.server_ip_address}"
     end
     text << "mw.b #{c.soc.load_address} 0xff 0x50000"
+    unlock_flash text, c
     if c.sd_card_slot.eql?('sd') && c.network_interface.eql?('wifi')
-      text << "fatload mmc 0:1 #{c.soc.load_address} #{c.soc.uboot_filename}"
+      text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{c.soc.uboot_filename}",
+                            '0x0', '0x50000', write_size)
     else
-      text << "tftpboot #{c.soc.load_address} #{c.soc.uboot_filename}"
+      text << guarded_flash(c, "tftpboot #{c.soc.load_address} #{c.soc.uboot_filename}",
+                            '0x0', '0x50000', write_size)
       text << '# if there is no tftpboot but tftp then run this instead'
-      text << "tftp #{c.soc.load_address} #{c.soc.uboot_filename}"
-    end
-    if c.flash_type.eql?('nand')
-      text << "nand erase 0x0 0x50000; nand write #{c.soc.load_address} 0x0 0x50000"
-    else
-      text << 'sf probe 0; sf lock 0;'
-      text << "sf erase 0x0 0x50000; sf write #{c.soc.load_address} 0x0 0x50000"
+      text << guarded_flash(c, "tftp #{c.soc.load_address} #{c.soc.uboot_filename}",
+                            '0x0', '0x50000', write_size)
     end
     text << 'reset'
     list_of_commands text
@@ -93,22 +126,14 @@ module InstallationHelper
     end
     if c.sd_card_slot.eql?('sd') && c.network_interface.eql?('wifi')
       text << "mw.b #{c.soc.load_address} 0xff 0x200000"
-      text << "fatload mmc 0:1 #{c.soc.load_address} #{c.soc.kernel_file}"
-      if c.flash_type.eql?('nand')
-        text << "nand erase #{c.kernel_offset} #{c.kernel_max_size}; nand write #{c.soc.load_address} #{c.kernel_offset} ${filesize}"
-      else
-        text << 'sf probe 0; sf lock 0;'
-        text << "sf erase #{c.kernel_offset} #{c.kernel_max_size}; sf write #{c.soc.load_address} #{c.kernel_offset} ${filesize}"
-      end
+      unlock_flash text, c
+      text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{c.soc.kernel_file}",
+                            c.kernel_offset, c.kernel_max_size, '${filesize}')
       text << ''
       text << "mw.b #{c.soc.load_address} 0xff 0x500000"
-      text << "fatload mmc 0:1 #{c.soc.load_address} #{c.soc.rootfs_file}"
-      if c.flash_type.eql?('nand')
-        text << "nand erase #{c.rootfs_offset} #{c.rootfs_max_size}; nand write #{c.soc.load_address} #{c.rootfs_offset} ${filesize}"
-      else
-        text << 'sf probe 0; sf lock 0;'
-        text << "sf erase #{c.rootfs_offset} #{c.rootfs_max_size}; sf write #{c.soc.load_address} #{c.rootfs_offset} ${filesize}"
-      end
+      unlock_flash text, c
+      text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{c.soc.rootfs_file}",
+                            c.rootfs_offset, c.rootfs_max_size, '${filesize}')
       text << ''
     else
       text << "run uk#{c2}; run ur#{c2}"
@@ -130,22 +155,20 @@ module InstallationHelper
   end
 
   def restore_from_backup(c)
+    write_size = write_size_for(c, c.flash_size_hex)
     text = []
     text << do_not_copy_paste
     unless c.network_interface.eql?('wifi')
       text << "setenv ipaddr #{c.camera_ip_address}; setenv serverip #{c.server_ip_address}"
     end
     text << "mw.b #{c.soc.load_address} 0xff #{c.flash_size_hex}"
+    unlock_flash text, c
     if c.sd_card_slot.eql?('sd') && c.network_interface.eql?('wifi')
-      text << "fatload mmc 0:1 #{c.soc.load_address} #{c.backup_filename}"
+      text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{c.backup_filename}",
+                            '0x0', c.flash_size_hex, write_size)
     else
-      text << "tftpboot #{c.soc.load_address} #{c.backup_filename}"
-    end
-    if c.flash_type.eql?('nand')
-      text << "nand erase 0x0 #{c.flash_size_hex}; nand write #{c.soc.load_address} 0x0 #{c.flash_size_hex}"
-    else
-      text << 'sf probe 0; sf lock 0;'
-      text << "sf erase 0x0 #{c.flash_size_hex}; sf write #{c.soc.load_address} 0x0 #{c.flash_size_hex}"
+      text << guarded_flash(c, "tftpboot #{c.soc.load_address} #{c.backup_filename}",
+                            '0x0', c.flash_size_hex, write_size)
     end
     list_of_commands text
   end


### PR DESCRIPTION
Fixes #55.

## The problem

The generated command blocks pre-fill RAM with `0xff` (`mw.b`) and then run the erase and write **unconditionally**, at a hardcoded full-region length. So a transfer that fails — or one whose load address was mistyped — is indistinguishable from one that worked: the erase still runs, and the write pushes the `0xff` fill over the bootloader while reporting success.

That is how the camera in OpenIPC/firmware#2299 was destroyed. Its flash offset 0 is now blank, the mask ROM loops printing `System startup`, and the only way back in is the SoC's UART download mode.

## The fix

Chain the transfer into the erase and write with `&&`, and bound NOR writes with `${filesize}`:

```diff
-tftpboot 0x82000000 openipc-hi3518ev200-lite-16mb.bin
-sf probe 0; sf lock 0;
-sf erase 0x0 0x1000000; sf write 0x82000000 0x0 0x1000000
+sf probe 0; sf lock 0;
+tftpboot 0x82000000 openipc-hi3518ev200-lite-16mb.bin && sf erase 0x0 0x1000000 && sf write 0x82000000 0x0 ${filesize}
```

This is the shape OpenIPC's own U-Boot env vars have always used — from a real `printenv` on hi3518ev200 in OpenIPC/firmware#695:

```
uknor16m=mw.b ${baseaddr} ff 1000000; tftpboot ${baseaddr} uImage.${soc} && sf probe 0; sf erase 0x50000 0x300000; sf write ${baseaddr} 0x50000 ${filesize}
```

and the shape `wiki/en/install-hisi.md` documents. Only the generator dropped both guards.

It has to stay a single line, because the block header tells the user to enter commands one at a time.

## Decisions worth reviewing

- **NAND write lengths are left at the fixed partition size.** `${filesize}` is not guaranteed to be page-aligned and `nand write` is picky about that. NAND still gains the `&&` guard, which is the part that prevents the brick.
- **`sf probe 0; sf lock 0;` moves ahead of the transfer and stays unchained.** Many vendor U-Boots have no `sf lock` subcommand; chaining it would abort on their error and stop the user flashing at all. `sf probe` still precedes the erase, which is all it needs to do.
- **`mw.b` is kept.** Once the erase is guarded it can no longer cause a brick, and it still pads the tail of a short transfer deterministically. Dropping it would be a reasonable follow-up but is a bigger behavioural change than this fix needs.
- **`&&` requires the hush parser.** OpenIPC's own env vars and the wiki already rely on it, so it is established on these U-Boots. A vendor U-Boot with the simple parser would fail on the `&&` — loudly, which is the correct direction to fail.

## Scope

`flashing_everything`, `flashing_uboot`, `restore_from_backup`, and the SD branch of `flashing_linux`.

`restore_from_backup` matters most of the four: it is the recovery path, so a failed transfer there bricked the camera someone was trying to un-brick.

`firmware_backup` is untouched apart from one added comment — it reads flash and uploads, so it erases nothing. The comment records that `tftp`'s third argument is what makes it upload rather than download, since the page offers `tftp <addr> <file> <len>` for backup and `tftp <addr> <file>` for flashing with nothing saying the third argument reverses the direction.

## Verification

**This is not hardware-tested, and the Ruby was not executed** — no Ruby or working Docker on the machine I wrote it on. What I did do was transliterate the helper before and after and render both, for a NOR and a NAND case:

<details>
<summary>hi3518ev200 / NOR 16M / Lite — "Flashing everything"</summary>

before
```
setenv ipaddr 10.0.0.161; setenv serverip 10.0.0.148
mw.b 0x82000000 0xff 0x1000000
tftpboot 0x82000000 openipc-hi3518ev200-lite-16mb.bin
# if there is no tftpboot but tftp then run this instead
tftp 0x82000000 openipc-hi3518ev200-lite-16mb.bin
sf probe 0; sf lock 0;
sf erase 0x0 0x1000000; sf write 0x82000000 0x0 0x1000000
reset
```

after
```
setenv ipaddr 10.0.0.161; setenv serverip 10.0.0.148
mw.b 0x82000000 0xff 0x1000000
sf probe 0; sf lock 0;
tftpboot 0x82000000 openipc-hi3518ev200-lite-16mb.bin && sf erase 0x0 0x1000000 && sf write 0x82000000 0x0 ${filesize}
# if there is no tftpboot but tftp then run this instead
tftp 0x82000000 openipc-hi3518ev200-lite-16mb.bin && sf erase 0x0 0x1000000 && sf write 0x82000000 0x0 ${filesize}
reset
```
</details>

<details>
<summary>hi3516ev300 / NAND / Ultimate — "Flashing everything"</summary>

before
```
setenv ipaddr 192.168.1.10; setenv serverip 192.168.1.254
mw.b 0x42000000 0xff 0x800000
tftpboot 0x42000000 openipc-hi3516ev300-ultimate-8mb.bin
# if there is no tftpboot but tftp then run this instead
tftp 0x42000000 openipc-hi3516ev300-ultimate-8mb.bin
nand erase 0x0 0x800000; nand write 0x42000000 0x0 0x800000
reset
```

after
```
setenv ipaddr 192.168.1.10; setenv serverip 192.168.1.254
mw.b 0x42000000 0xff 0x800000
tftpboot 0x42000000 openipc-hi3516ev300-ultimate-8mb.bin && nand erase 0x0 0x800000 && nand write 0x42000000 0x0 0x800000
# if there is no tftpboot but tftp then run this instead
tftp 0x42000000 openipc-hi3516ev300-ultimate-8mb.bin && nand erase 0x0 0x800000 && nand write 0x42000000 0x0 0x800000
reset
```
</details>

<details>
<summary>hi3518ev200 / NOR 16M — "Restore from backup"</summary>

before
```
setenv ipaddr 10.0.0.161; setenv serverip 10.0.0.148
mw.b 0x82000000 0xff 0x1000000
tftpboot 0x82000000 backup-hi3518ev200-nor16m.bin
sf probe 0; sf lock 0;
sf erase 0x0 0x1000000; sf write 0x82000000 0x0 0x1000000
```

after
```
setenv ipaddr 10.0.0.161; setenv serverip 10.0.0.148
mw.b 0x82000000 0xff 0x1000000
sf probe 0; sf lock 0;
tftpboot 0x82000000 backup-hi3518ev200-nor16m.bin && sf erase 0x0 0x1000000 && sf write 0x82000000 0x0 ${filesize}
```
</details>

Someone with a Rails env should render the real page for a NOR and a NAND SoC before this merges — the transliteration checks my intent, not the Ruby.
