### PR TITLE
Build the NAND full image from what a NAND build actually ships

### DIFF
--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -114,10 +114,13 @@ module Cameras
       fw = Firmware.new(size: flash_size, flash_type: flash_type, release: fw_release, soc: @soc)
       fw.generate
       send_file fw.filepath, name: fw.filename, disposition: :attachment
-    rescue ActionController::MissingFile, Firmware::MissingMember => e
+    rescue ActionController::MissingFile, Firmware::MissingMember, Firmware::InvalidFlashSize => e
       # MissingMember means the release tarball does not carry what this flash
       # type needs -- a NAND build with no kernel member, say. Better a missing
       # download than an image with a hole where the rootfs should be.
+      # InvalidFlashSize means flash_size was not one this generator builds for;
+      # it arrives straight from the query string, so it is refused before it
+      # can be turned into an allocation.
       Rails.logger.warn "full image unavailable for #{params[:id]}: #{e.message}"
       flash.alert = 'This firmware does not exist.'
       redirect_back(fallback_location: '/')

--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -114,7 +114,11 @@ module Cameras
       fw = Firmware.new(size: flash_size, flash_type: flash_type, release: fw_release, soc: @soc)
       fw.generate
       send_file fw.filepath, name: fw.filename, disposition: :attachment
-    rescue ActionController::MissingFile => e
+    rescue ActionController::MissingFile, Firmware::MissingMember => e
+      # MissingMember means the release tarball does not carry what this flash
+      # type needs -- a NAND build with no kernel member, say. Better a missing
+      # download than an image with a hole where the rootfs should be.
+      Rails.logger.warn "full image unavailable for #{params[:id]}: #{e.message}"
       flash.alert = 'This firmware does not exist.'
       redirect_back(fallback_location: '/')
     end

--- a/app/helpers/installation_helper.rb
+++ b/app/helpers/installation_helper.rb
@@ -72,12 +72,16 @@ module InstallationHelper
   end
 
   def flashing_everything(c)
-    fw_filename = "openipc-#{c.soc.model_downcase}-#{c.firmware_version}-#{c.flash_size}mb.bin"
-    write_size = write_size_for(c, c.flash_size_hex)
+    fw_filename = Firmware.filename_for(soc_model: c.soc.model_downcase, flash_type: c.flash_type_type,
+                                        release: c.firmware_version, size: c.flash_size)
+    # The full image is exactly the size it claims on NOR and page-aligned by
+    # construction on NAND, so ${filesize} is always a safe write length here --
+    # unlike the u-boot-only block below, where the binary is neither.
+    write_size = '${filesize}'
     text = []
     text << do_not_copy_paste
     text << "setenv ipaddr #{c.camera_ip_address}; setenv serverip #{c.server_ip_address}"
-    text << "mw.b #{c.soc.load_address} 0xff #{c.flash_size_hex}"
+    text << "mw.b #{c.soc.load_address} 0xff #{c.staging_size_hex}"
     unlock_flash text, c
     if c.sd_card_slot.eql?('sd') && c.network_interface.eql?('wifi')
       text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{fw_filename}",
@@ -138,11 +142,12 @@ module InstallationHelper
     else
       text << "run uk#{c2}; run ur#{c2}"
     end
-    if c.flash_type.eql?('nand')
-      text << "nand erase #{c.overlay_offset} #{c.overlay_max_size}"
-    else
-      text << "sf erase #{c.overlay_offset} #{c.overlay_max_size}"
-    end
+    # No overlay erase on NAND: with mtdpartsubi everything past the kernel is
+    # one `ubi` partition and rootfs_data is a volume inside it, so a raw erase
+    # at an offset would cut into UBI. `urnand` already erases that whole
+    # partition before writing. This is also what used to render the malformed
+    # `nand erase 0xD50000 0x-550000`.
+    text << "sf erase #{c.overlay_offset} #{c.overlay_max_size}" unless c.flash_type.eql?('nand')
     text << 'reset'
     list_of_commands text
   end
@@ -161,7 +166,7 @@ module InstallationHelper
     unless c.network_interface.eql?('wifi')
       text << "setenv ipaddr #{c.camera_ip_address}; setenv serverip #{c.server_ip_address}"
     end
-    text << "mw.b #{c.soc.load_address} 0xff #{c.flash_size_hex}"
+    text << "mw.b #{c.soc.load_address} 0xff #{c.staging_size_hex}"
     unlock_flash text, c
     if c.sd_card_slot.eql?('sd') && c.network_interface.eql?('wifi')
       text << guarded_flash(c, "fatload mmc 0:1 #{c.soc.load_address} #{c.backup_filename}",

--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -9,6 +9,26 @@ class Camera
   NET_IFACE = %w[eth wifi both].freeze
   SD_CARD = %w[nosd sd].freeze
 
+  # NAND geometry. The parts OpenIPC ships NAND builds for are 1Gbit SPI-NAND:
+  # 128MiB, 2KiB page, 128KiB erase block. The layout below is the HiSilicon /
+  # Goke `mtdpartsubi` one -- 256k(boot),768k(wtf),3072k(kernel),-(ubi) -- as
+  # read from a real `printenv` in OpenIPC/firmware#695. It is family specific,
+  # not universal; SigmaStar and Rockchip carry their kernel inside the UBI
+  # image instead and are refused by Firmware#generate.
+  NAND_SIZE_HEX = '0x8000000'
+  NAND_KERNEL_OFFSET = '0x100000'
+  NAND_KERNEL_MAX_SIZE = '0x300000'
+  NAND_ROOTFS_OFFSET = '0x400000'
+  NAND_ROOTFS_MAX_SIZE = '0x7c00000'
+
+  # What `mw.b` pre-fills before a transfer, i.e. how much RAM the image needs.
+  # It is the flash size on NOR, but it cannot be on NAND: the chip is 128MiB
+  # and these cameras have 64MB of RAM. A NAND full image stops after the UBI
+  # payload, so it is at most 0x400000 + the 16384KB rootfs.ubi cap the
+  # firmware Makefile enforces = 20MB exactly. 24MB leaves headroom for a cap
+  # bump and still fits at the load address.
+  NAND_STAGING_SIZE_HEX = '0x1800000'
+
   attr_accessor :soc_id, :needs_instruction, :flash_type, :sd_card_slot,
                 :network_interface, :camera_ip_address, :server_ip_address,
                 :firmware_version, :camera_mac_address, :soc, :backup_filename
@@ -36,6 +56,10 @@ class Camera
     @backup_filename ||= "backup-#{model.downcase}-#{@flash_type}.bin"
   end
 
+  def nand?
+    @flash_type.eql?('nand')
+  end
+
   def flash_type_type
     case @flash_type
     when 'nor8m', 'nor16m', 'nor32m'
@@ -55,8 +79,8 @@ class Camera
       16
     when 'nor32m'
       32
-      # when 'nand'
-      #   ??
+    when 'nand'
+      128
     else
       8
     end
@@ -70,8 +94,8 @@ class Camera
       '0x8000'
     when 'nor32m'
       '0x16000'
-      # when 'nand'
-      #   ??
+    when 'nand'
+      '0x40000'
     else
       '0x4000'
     end
@@ -85,11 +109,15 @@ class Camera
       '0x1000000'
     when 'nor32m'
       '0x2000000'
-    # when 'nand'
-    #   ??
+    when 'nand'
+      NAND_SIZE_HEX
     else
       '0x800000'
     end
+  end
+
+  def staging_size_hex
+    nand? ? NAND_STAGING_SIZE_HEX : flash_size_hex
   end
 
   def flash_size_sectors
@@ -100,8 +128,8 @@ class Camera
       '32768'
     when 'nor32m'
       '65536'
-      # when 'nand'
-      #   ??
+    when 'nand'
+      '262144'
     end
   end
 
@@ -110,9 +138,9 @@ class Camera
   end
 
   def kernel_max_size
+    return NAND_KERNEL_MAX_SIZE if nand?
+
     case firmware_version
-    when 'lite'
-      '0x200000'
     when 'ultimate'
       '0x300000'
     else
@@ -121,20 +149,13 @@ class Camera
   end
 
   def kernel_offset
-    case firmware_version
-    when 'lite'
-      '0x50000'
-    when 'ultimate'
-      '0x50000'
-    else
-      '0x50000'
-    end
+    nand? ? NAND_KERNEL_OFFSET : '0x50000'
   end
 
   def rootfs_max_size
+    return NAND_ROOTFS_MAX_SIZE if nand?
+
     case firmware_version
-    when 'lite'
-      '0x500000'
     when 'ultimate'
       '0xA00000'
     else
@@ -143,9 +164,9 @@ class Camera
   end
 
   def rootfs_offset
+    return NAND_ROOTFS_OFFSET if nand?
+
     case firmware_version
-    when 'lite'
-      '0x250000'
     when 'ultimate'
       '0x350000'
     else
@@ -153,14 +174,19 @@ class Camera
     end
   end
 
+  # Guards the arithmetic that used to render `nand erase 0xD50000 0x-550000`:
+  # NAND fell through to the 8MB NOR default, so flash_size_hex was smaller
+  # than overlay_offset and the subtraction went negative. U-Boot's
+  # simple_strtoul stops at the '-', silently turning the size into 0.
   def overlay_max_size
-    "0x#{(flash_size_hex.to_i(16) - overlay_offset.to_i(16)).to_s(16)}"
+    size = flash_size_hex.to_i(16) - overlay_offset.to_i(16)
+    raise StandardError, "overlay_offset #{overlay_offset} is beyond flash size #{flash_size_hex}" if size <= 0
+
+    "0x#{size.to_s(16)}"
   end
 
   def overlay_offset
     case firmware_version
-    when 'lite'
-      '0x750000'
     when 'ultimate'
       '0xD50000'
     else

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -11,8 +11,10 @@ class Firmware
   NAND_ROOTFS_OFFSET = 0x400000
 
   NOR_KERNEL_OFFSET = 0x50000
+  NOR_SIZES = [8, 16, 32].freeze
 
   class MissingMember < StandardError; end
+  class InvalidFlashSize < StandardError; end
 
   def initialize(size: 8, flash_type: 'nor', release: 'lite', soc: nil)
     super()
@@ -44,6 +46,8 @@ class Firmware
   end
 
   def generate
+    validate_size!
+
     uboot_file = @soc.uboot_file
     unless File.exist?(uboot_file)
       puts "File #{uboot_file} not found."
@@ -64,32 +68,60 @@ class Firmware
       return
     end
 
-    members = read_members(linux_file)
-    kernel = fetch_member!(members, kernel_member, linux_file)
-    rootfs = fetch_member!(members, rootfs_member, linux_file)
+    data, present = read_members(linux_file, [kernel_member, rootfs_member])
+    kernel = fetch_member!(data, kernel_member, linux_file, present)
+    rootfs = fetch_member!(data, rootfs_member, linux_file, present)
+
+    # Resolve every offset and the length before allocating anything, so an
+    # unsupported size cannot get as far as filling a buffer with it.
+    k_offset = kernel_offset
+    r_offset = rootfs_offset
+    size = image_size(rootfs)
 
     # create directory
     FileUtils.mkdir_p File.dirname(filepath)
 
     tmp_file = Tempfile.create
-    IO.binwrite tmp_file, ("\xFF" * image_size(rootfs))
+    IO.binwrite tmp_file, ("\xFF" * size)
     IO.binwrite tmp_file, IO.binread(uboot_file), 0
-    IO.binwrite tmp_file, kernel, kernel_offset
-    IO.binwrite tmp_file, rootfs, rootfs_offset
+    IO.binwrite tmp_file, kernel, k_offset
+    IO.binwrite tmp_file, rootfs, r_offset
     FileUtils.mv tmp_file, filepath
   end
 
   private
 
-  # Read the archive once into name => bytes. TarReader#seek scans forward from
-  # the current position, so two successive seeks only work while the members
-  # happen to be in the order asked for; a hash does not care.
-  def read_members(linux_file)
-    {}.tap do |members|
-      Gem::Package::TarReader.new(Zlib::GzipReader.open(linux_file)) do |tar|
-        tar.each { |entry| members[entry.full_name] = entry.read if entry.file? }
+  # size is a request parameter, so it has to be checked before it can be turned
+  # into an allocation. Guarding here rather than relying on rootfs_offset to
+  # raise later keeps a crafted ?flash_size=<huge> from filling a buffer first.
+  # NAND ignores it entirely: that image is sized from its payload.
+  def validate_size!
+    return if nand?
+    return if NOR_SIZES.include?(@size)
+
+    raise InvalidFlashSize, "unsupported NOR flash size #{@size}MB (expected #{NOR_SIZES.join(', ')})"
+  end
+
+  # One pass, reading only the two bodies we need -- rootfs.ubi runs to 16MB and
+  # buffering every member would hold far more than the image itself. Names are
+  # collected for the error message, which costs nothing: skipped entries are
+  # stepped over by header, not read.
+  #
+  # A pass rather than two TarReader#seek calls because seek scans forward from
+  # the current position, so successive seeks only worked while the members
+  # happened to be in the order asked for.
+  def read_members(linux_file, wanted)
+    data = {}
+    present = []
+    Gem::Package::TarReader.new(Zlib::GzipReader.open(linux_file)) do |tar|
+      tar.each do |entry|
+        next unless entry.file?
+
+        present << entry.full_name
+        data[entry.full_name] = entry.read if wanted.include?(entry.full_name)
       end
     end
+    [data, present]
   end
 
   # The bug this class shipped for years: TarReader#seek yields nothing when the
@@ -99,12 +131,12 @@ class Firmware
   # Refusing loudly is also what keeps SigmaStar and Rockchip out: their NAND
   # tarballs carry no kernel member, because the kernel is a volume inside the
   # UBI image rather than a partition of its own.
-  def fetch_member!(members, name, linux_file)
-    data = members[name]
-    return data if data
+  def fetch_member!(data, name, linux_file, present)
+    body = data[name]
+    return body if body
 
-    present = members.keys.reject { |k| k.end_with?('.md5sum') }.join(', ')
-    raise MissingMember, "#{name} is not in #{File.basename(linux_file)} (members: #{present})"
+    listed = present.reject { |k| k.end_with?('.md5sum') }.join(', ')
+    raise MissingMember, "#{name} is not in #{File.basename(linux_file)} (members: #{listed})"
   end
 
   def soc_model
@@ -141,7 +173,7 @@ class Firmware
     when 16, 32
       0x350000
     else
-      raise StandardError, 'Unknown flash size'
+      raise InvalidFlashSize, "unsupported NOR flash size #{@size}MB"
     end
   end
 

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
+require 'rubygems/package'
+
 class Firmware
+  # NAND full images stop after the UBI payload rather than spanning the chip.
+  # The parts are 128MiB but the cameras have 64MB of RAM, so a chip-sized
+  # image could never be staged at the load address to be written from.
+  NAND_PAGE = 2048
+  NAND_KERNEL_OFFSET = 0x100000
+  NAND_ROOTFS_OFFSET = 0x400000
+
+  NOR_KERNEL_OFFSET = 0x50000
+
+  class MissingMember < StandardError; end
+
   def initialize(size: 8, flash_type: 'nor', release: 'lite', soc: nil)
     super()
     @soc = soc
@@ -9,16 +22,28 @@ class Firmware
     @release = release
   end
 
+  # Built here rather than in the view so the TFTP command on the installation
+  # page and the file the download actually produces cannot drift apart.
+  def self.filename_for(soc_model:, flash_type:, release:, size:)
+    return "openipc-#{soc_model}-nand-#{release}.bin" if flash_type.to_s.eql?('nand')
+
+    "openipc-#{soc_model}-nor-#{release}-#{size}mb.bin"
+  end
+
   def filename
-    @filename ||= "openipc-#{@soc.model_downcase}-#{@release}-#{@size}mb.bin"
+    @filename ||= self.class.filename_for(soc_model: @soc.model_downcase, flash_type: @flash_type,
+                                          release: @release, size: @size)
   end
 
   def filepath
     @filepath ||= File.join(Rails.root, 'public', 'files', filename)
   end
 
+  def nand?
+    @flash_type.to_s.eql?('nand')
+  end
+
   def generate
-    soc_model = @soc.model_downcase
     uboot_file = @soc.uboot_file
     unless File.exist?(uboot_file)
       puts "File #{uboot_file} not found."
@@ -32,51 +57,100 @@ class Firmware
     end
 
     # file exists and it is newer than any of its parts
-    if File.exist?(filepath) && 
+    if File.exist?(filepath) &&
         File.mtime(uboot_file) < File.mtime(filepath) &&
         File.mtime(linux_file) < File.mtime(filepath)
       puts "File #{filepath} exists and is fresh."
       return
     end
 
-    firmware_size = @size.megabytes
-    kernel_offset = 0x50000
-    case @size
-    when 8
-      rootfs_offset = 0x250000
-    when 16
-      rootfs_offset = 0x350000
-    when 32
-      rootfs_offset = 0x350000
-    else
-      raise StandardError, 'Unknown flash size'
-    end
-
-    rootfs_offset = 0x250000 if @soc.vendor.name.eql?('SigmaStar')
-    rootfs_offset = 0x250000 if @soc.vendor.name.eql?('Ingenic')
+    members = read_members(linux_file)
+    kernel = fetch_member!(members, kernel_member, linux_file)
+    rootfs = fetch_member!(members, rootfs_member, linux_file)
 
     # create directory
     FileUtils.mkdir_p File.dirname(filepath)
 
     tmp_file = Tempfile.create
-    IO.binwrite tmp_file, ("\xFF" * firmware_size)
+    IO.binwrite tmp_file, ("\xFF" * image_size(rootfs))
     IO.binwrite tmp_file, IO.binread(uboot_file), 0
-    Gem::Package::TarReader.new(Zlib::GzipReader.open(linux_file)) do |tar|
-      kernel_file = "uImage.#{soc_model}"
-      rootfs_file = "rootfs.squashfs.#{soc_model}"
-
-      # workaround for Ingenic T31/T40 where there's the same file for all models
-      if soc_model.starts_with?('t31')
-        kernel_file = 'uImage.t31'
-        rootfs_file = 'rootfs.squashfs.t31'
-      elsif soc_model.starts_with?('t40')
-        kernel_file = 'uImage.t40'
-        rootfs_file = 'rootfs.squashfs.t40'
-      end
-
-      tar.seek(kernel_file) { |f| IO.binwrite tmp_file, f.read, kernel_offset }
-      tar.seek(rootfs_file) { |f| IO.binwrite tmp_file, f.read, rootfs_offset }
-    end
+    IO.binwrite tmp_file, kernel, kernel_offset
+    IO.binwrite tmp_file, rootfs, rootfs_offset
     FileUtils.mv tmp_file, filepath
+  end
+
+  private
+
+  # Read the archive once into name => bytes. TarReader#seek scans forward from
+  # the current position, so two successive seeks only work while the members
+  # happen to be in the order asked for; a hash does not care.
+  def read_members(linux_file)
+    {}.tap do |members|
+      Gem::Package::TarReader.new(Zlib::GzipReader.open(linux_file)) do |tar|
+        tar.each { |entry| members[entry.full_name] = entry.read if entry.file? }
+      end
+    end
+  end
+
+  # The bug this class shipped for years: TarReader#seek yields nothing when the
+  # member is absent and the return value was never checked, so a NAND build --
+  # whose rootfs is named rootfs.ubi, not rootfs.squashfs -- produced an image
+  # with no root filesystem in it at all, served as though it were complete.
+  # Refusing loudly is also what keeps SigmaStar and Rockchip out: their NAND
+  # tarballs carry no kernel member, because the kernel is a volume inside the
+  # UBI image rather than a partition of its own.
+  def fetch_member!(members, name, linux_file)
+    data = members[name]
+    return data if data
+
+    present = members.keys.reject { |k| k.end_with?('.md5sum') }.join(', ')
+    raise MissingMember, "#{name} is not in #{File.basename(linux_file)} (members: #{present})"
+  end
+
+  def soc_model
+    @soc_model ||= @soc.model_downcase
+  end
+
+  def kernel_member
+    # Ingenic ships one kernel for the whole family rather than one per model.
+    return 'uImage.t31' if soc_model.starts_with?('t31')
+    return 'uImage.t40' if soc_model.starts_with?('t40')
+
+    "uImage.#{soc_model}"
+  end
+
+  def rootfs_member
+    return "rootfs.ubi.#{soc_model}" if nand?
+    return 'rootfs.squashfs.t31' if soc_model.starts_with?('t31')
+    return 'rootfs.squashfs.t40' if soc_model.starts_with?('t40')
+
+    "rootfs.squashfs.#{soc_model}"
+  end
+
+  def kernel_offset
+    nand? ? NAND_KERNEL_OFFSET : NOR_KERNEL_OFFSET
+  end
+
+  def rootfs_offset
+    return NAND_ROOTFS_OFFSET if nand?
+    return 0x250000 if @soc.vendor.name.eql?('SigmaStar') || @soc.vendor.name.eql?('Ingenic')
+
+    case @size
+    when 8
+      0x250000
+    when 16, 32
+      0x350000
+    else
+      raise StandardError, 'Unknown flash size'
+    end
+  end
+
+  def image_size(rootfs)
+    return @size.megabytes unless nand?
+
+    end_of_rootfs = NAND_ROOTFS_OFFSET + rootfs.bytesize
+    # Page-align so the generated image can be written with ${filesize}; U-Boot
+    # `nand write` rejects a length that is not a multiple of the page size.
+    (end_of_rootfs + NAND_PAGE - 1) / NAND_PAGE * NAND_PAGE
   end
 end

--- a/app/views/cameras/socs/update.html.erb
+++ b/app/views/cameras/socs/update.html.erb
@@ -57,8 +57,11 @@
           <div class="github">
             <i class="bi bi-github float-start me-2"></i>
             <h6 class="mb-0"><%= link_to t('firmware.installation.flashing_full.link', name: @camera.firmware_version.to_s.titleize), download_full_image_cameras_vendor_soc_path(@camera.soc.vendor, @camera.soc, fw_release: @camera.firmware_version, flash_size: @camera.flash_size, flash_type: @camera.flash_type_type) %></h6>
-            <p>for <%= @camera.soc.full_name %> with <%= @camera.flash_size %>MB NOR flash</p>
+            <p>for <%= @camera.soc.full_name %> with <%= @camera.flash_size %>MB <%= @camera.flash_type_type.upcase %> flash</p>
             <p class="mb-0"><%= t('firmware.installation.flashing_full.info') %></p>
+            <% if @camera.nand? %>
+              <p class="mb-0 mt-2 small"><%= t('firmware.installation.flashing_full.nand_caveat') %></p>
+            <% end %>
           </div>
         </div>
         <div class="col">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,7 @@ en:
         continue2: Stay focused and prepare to interrupt the booting sequence in order to get back into the bootloader shell. When in the bootloader shell, remap ROM partitioning according to your flash size and type.
         info: The full firmware image consists of bootloader, kernel and root filesystem, and is also suitable for flashing memory chip using a programmer. Please note, the full image does not contain pre-set environment. You still need to add your own MAC address, IP address and other settings.
         link: Download OpenIPC Firmware (%{name}) image
+        nand_caveat: On NAND the image covers the bootloader, kernel and UBI root filesystem only, not the whole chip, and it is not suitable for a programmer -- it carries no OOB/ECC bytes and no factory bad-block markers. Write it from U-Boot, or use the per-partition commands below.
         title: Flash full OpenIPC Firmware image
       flashing_uboot:
         continue: The camera will boot into the newly flashed bootloader. Stay focused and prepare to interrupt the booting sequence in order to get back into the bootloader shell.

--- a/test/models/camera_test.rb
+++ b/test/models/camera_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CameraTest < ActiveSupport::TestCase
+  def camera(flash_type:, firmware_version: 'ultimate')
+    Camera.new(flash_type: flash_type, firmware_version: firmware_version)
+  end
+
+  # --- NOR regressions: these values render on every existing SoC page ---
+
+  test 'nor geometry is unchanged' do
+    c = camera(flash_type: 'nor16m')
+    assert_equal '0x1000000', c.flash_size_hex
+    assert_equal 16, c.flash_size
+    assert_equal '0x50000', c.kernel_offset
+    assert_equal '0x350000', c.rootfs_offset
+    assert_equal '0xA00000', c.rootfs_max_size
+    assert_equal '0x300000', c.kernel_max_size
+  end
+
+  test 'nor lite geometry is unchanged' do
+    c = camera(flash_type: 'nor8m', firmware_version: 'lite')
+    assert_equal '0x800000', c.flash_size_hex
+    assert_equal '0x250000', c.rootfs_offset
+    assert_equal '0x500000', c.rootfs_max_size
+    assert_equal '0x200000', c.kernel_max_size
+  end
+
+  test 'staging size equals flash size on nor' do
+    %w[nor8m nor16m nor32m].each do |t|
+      c = camera(flash_type: t)
+      assert_equal c.flash_size_hex, c.staging_size_hex, "staging size drifted for #{t}"
+    end
+  end
+
+  # --- NAND ---
+
+  test 'nand reports the real chip size rather than the 8MB nor default' do
+    c = camera(flash_type: 'nand')
+    assert_equal '0x8000000', c.flash_size_hex
+    assert_equal 128, c.flash_size
+    assert_equal '262144', c.flash_size_sectors
+    assert_equal '0x40000', c.flash_size_blocks
+  end
+
+  test 'nand stages a RAM-sized buffer, not the whole chip' do
+    c = camera(flash_type: 'nand')
+    # A 128MiB mw.b would run off the end of RAM on a 64MB camera.
+    assert_equal '0x1800000', c.staging_size_hex
+    assert c.staging_size_hex.to_i(16) < c.flash_size_hex.to_i(16)
+    # Must still cover the largest image the firmware Makefile can produce:
+    # rootfs.ubi offset plus its 16384KB cap.
+    assert c.staging_size_hex.to_i(16) >= c.rootfs_offset.to_i(16) + (16_384 * 1024)
+  end
+
+  test 'nand uses the ubi layout offsets, not the nor ones' do
+    c = camera(flash_type: 'nand')
+    assert_equal '0x100000', c.kernel_offset
+    assert_equal '0x300000', c.kernel_max_size
+    assert_equal '0x400000', c.rootfs_offset
+    assert_equal '0x7c00000', c.rootfs_max_size
+  end
+
+  test 'nand rootfs partition runs to the end of the chip' do
+    c = camera(flash_type: 'nand')
+    assert_equal c.flash_size_hex.to_i(16),
+                 c.rootfs_offset.to_i(16) + c.rootfs_max_size.to_i(16)
+  end
+
+  test 'nand? only answers for nand' do
+    assert camera(flash_type: 'nand').nand?
+    assert_not camera(flash_type: 'nor16m').nand?
+  end
+
+  # --- the malformed-erase guard ---
+
+  test 'overlay_max_size refuses to return a negative length' do
+    # This is what rendered `nand erase 0xD50000 0x-550000`: an overlay offset
+    # past the end of the flash. U-Boot parses that size as 0 and erases nothing.
+    c = camera(flash_type: 'nor8m', firmware_version: 'ultimate')
+    assert c.overlay_offset.to_i(16) > c.flash_size_hex.to_i(16)
+    assert_raises(StandardError) { c.overlay_max_size }
+  end
+
+  test 'overlay_max_size is positive where the layout is coherent' do
+    c = camera(flash_type: 'nor16m', firmware_version: 'ultimate')
+    assert_equal '0x2b0000', c.overlay_max_size
+  end
+end

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 require 'rubygems/package'
 require 'zlib'
 require 'tmpdir'
+require 'benchmark'
 
 class FirmwareTest < ActiveSupport::TestCase
   StubVendor = Struct.new(:name)
@@ -133,6 +134,56 @@ class FirmwareTest < ActiveSupport::TestCase
 
     error = assert_raises(Firmware::MissingMember) { fw.generate }
     assert_match(/rootfs\.squashfs\.hi3516ev300/, error.message)
+  end
+
+  # --- flash_size arrives straight from the query string ---
+
+  test 'an unsupported nor size is refused before anything is allocated' do
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nor', size: 999_999,
+               members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.squashfs.hi3516ev300' => SQUASHFS })
+
+    # Must raise on the size itself, not after filling 999999MB of buffer.
+    elapsed = Benchmark.realtime { assert_raises(Firmware::InvalidFlashSize) { fw.generate } }
+    assert elapsed < 5, "took #{elapsed}s -- the size was allocated before it was checked"
+    assert_not File.exist?(fw.filepath)
+  end
+
+  test 'every supported nor size is accepted' do
+    [8, 16, 32].each do |size|
+      fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nor', size: size,
+                 members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.squashfs.hi3516ev300' => SQUASHFS })
+      fw.generate
+      assert_equal size.megabytes, File.size(fw.filepath), "size #{size} did not generate"
+    end
+  end
+
+  test 'nand ignores the size parameter entirely' do
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nand', size: 999_999,
+               members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI })
+    fw.generate
+
+    assert_equal 0x400000 + UBI.bytesize, File.size(fw.filepath),
+                 'a NAND image is sized from its payload, never from the parameter'
+  end
+
+  test 'only the members needed are read into memory' do
+    big = "\x00".b * (4 * 1024 * 1024)
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nand', size: 128,
+               members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI,
+                          'unrelated.blob' => big })
+    fw.generate
+
+    # The unrelated member must not appear anywhere in the assembled image.
+    assert_equal UBI, IO.binread(fw.filepath)[0x400000, UBI.bytesize]
+    assert File.size(fw.filepath) < big.bytesize, 'an unwanted member leaked into the image'
+  end
+
+  test 'the missing-member error still names what the tarball does hold' do
+    fw = build(model: 'ssc338q', vendor: 'SigmaStar', flash_type: 'nand', size: 128,
+               members: { 'rootfs.ubi.ssc338q' => UBI })
+
+    error = assert_raises(Firmware::MissingMember) { fw.generate }
+    assert_match(/members: rootfs\.ubi\.ssc338q/, error.message)
   end
 
   test 'member order in the tarball does not matter' do

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rubygems/package'
+require 'zlib'
+require 'tmpdir'
+
+class FirmwareTest < ActiveSupport::TestCase
+  StubVendor = Struct.new(:name)
+
+  class StubSoc
+    attr_reader :model_downcase, :vendor, :uboot_file
+
+    def initialize(model:, vendor:, uboot_file:, linux_file:)
+      @model_downcase = model
+      @vendor = StubVendor.new(vendor)
+      @uboot_file = uboot_file
+      @linux_file = linux_file
+    end
+
+    def linux_file(_release, _flash_type)
+      @linux_file
+    end
+  end
+
+  UBOOT = "\x17\x04\x00\xEA".b + ("\x5A".b * 0x2000)
+  KERNEL = "\x27\x05\x19\x56".b + ("\xA5".b * 0x1000)
+  SQUASHFS = 'hsqs'.b + ("\xC3".b * 0x2000)
+  UBI = 'UBI#'.b + ("\xD7".b * 0x3000)
+
+  def setup
+    @dir = Dir.mktmpdir
+    @generated = []
+  end
+
+  def teardown
+    FileUtils.remove_entry(@dir)
+    @generated.each { |f| FileUtils.rm_f(f) }
+  end
+
+  def write_tgz(name, members)
+    path = File.join(@dir, name)
+    Zlib::GzipWriter.open(path) do |gz|
+      Gem::Package::TarWriter.new(gz) do |tar|
+        members.each do |member, data|
+          tar.add_file_simple(member, 0o644, data.bytesize) { |io| io.write(data) }
+        end
+      end
+    end
+    path
+  end
+
+  def uboot_path
+    @uboot_path ||= File.join(@dir, 'u-boot.bin').tap { |p| IO.binwrite(p, UBOOT) }
+  end
+
+  def build(model:, vendor:, members:, flash_type:, size:, release: 'ultimate')
+    soc = StubSoc.new(model: model, vendor: vendor, uboot_file: uboot_path,
+                      linux_file: write_tgz("openipc.#{model}-#{flash_type}-#{release}.tgz", members))
+    fw = Firmware.new(size: size, flash_type: flash_type, release: release, soc: soc)
+    @generated << fw.filepath
+    FileUtils.rm_f(fw.filepath)
+    fw
+  end
+
+  # --- filename ---
+
+  test 'filename carries the flash type so nor and nand cannot share a cache file' do
+    nor = Firmware.filename_for(soc_model: 'hi3516ev300', flash_type: 'nor', release: 'ultimate', size: 16)
+    nand = Firmware.filename_for(soc_model: 'hi3516ev300', flash_type: 'nand', release: 'ultimate', size: 16)
+    assert_equal 'openipc-hi3516ev300-nor-ultimate-16mb.bin', nor
+    assert_equal 'openipc-hi3516ev300-nand-ultimate.bin', nand
+    assert_not_equal nor, nand
+  end
+
+  # --- NOR regression ---
+
+  test 'nor image keeps its layout' do
+    fw = build(model: 'hi3518ev200', vendor: 'HiSilicon', flash_type: 'nor', size: 16,
+               members: { 'uImage.hi3518ev200' => KERNEL, 'rootfs.squashfs.hi3518ev200' => SQUASHFS })
+    fw.generate
+    image = IO.binread(fw.filepath)
+
+    assert_equal 16.megabytes, image.bytesize
+    assert_equal UBOOT, image[0, UBOOT.bytesize]
+    assert_equal KERNEL, image[0x50000, KERNEL.bytesize]
+    assert_equal SQUASHFS, image[0x350000, SQUASHFS.bytesize]
+  end
+
+  # --- NAND ---
+
+  test 'nand image takes rootfs.ubi and puts it at the ubi offset' do
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nand', size: 128,
+               members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI })
+    fw.generate
+    image = IO.binread(fw.filepath)
+
+    assert_equal UBOOT, image[0, UBOOT.bytesize]
+    assert_equal KERNEL, image[0x100000, KERNEL.bytesize], 'kernel belongs at the NAND offset'
+    assert_equal UBI, image[0x400000, UBI.bytesize], 'rootfs.ubi belongs at the UBI offset'
+    assert_equal 'UBI#', image[0x400000, 4]
+  end
+
+  test 'nand image stops after the payload and is page aligned' do
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nand', size: 128,
+               members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI })
+    fw.generate
+    size = File.size(fw.filepath)
+
+    assert_equal 0, size % 2048, 'nand write rejects a non-page-aligned length'
+    assert size >= 0x400000 + UBI.bytesize
+    assert size < 0x8000000, 'a chip-sized image could not be staged in 64MB of RAM'
+  end
+
+  # --- the silent hole this PR closes ---
+
+  test 'a nand tarball with no kernel is refused rather than served' do
+    # SigmaStar and Rockchip carry the kernel as a volume inside rootfs.ubi, so
+    # their NAND tarball has no uImage member and no full image can be built.
+    fw = build(model: 'ssc338q', vendor: 'SigmaStar', flash_type: 'nand', size: 128,
+               members: { 'rootfs.ubi.ssc338q' => UBI })
+
+    error = assert_raises(Firmware::MissingMember) { fw.generate }
+    assert_match(/uImage\.ssc338q/, error.message)
+    assert_not File.exist?(fw.filepath), 'nothing may be left behind for send_file to serve'
+  end
+
+  test 'a nor tarball without a squashfs is refused rather than silently omitted' do
+    # The original bug: NAND tarballs ship rootfs.ubi, the generator asked for
+    # rootfs.squashfs, TarReader#seek returned nil, and the rootfs was dropped.
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nor', size: 16,
+               members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI })
+
+    error = assert_raises(Firmware::MissingMember) { fw.generate }
+    assert_match(/rootfs\.squashfs\.hi3516ev300/, error.message)
+  end
+
+  test 'member order in the tarball does not matter' do
+    fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nand', size: 128,
+               members: { 'rootfs.ubi.hi3516ev300' => UBI, 'uImage.hi3516ev300' => KERNEL })
+    fw.generate
+
+    assert_equal KERNEL, IO.binread(fw.filepath)[0x100000, KERNEL.bytesize]
+  end
+end


### PR DESCRIPTION
Fixes #58.

## What was wrong

`Firmware#generate` has never had NAND handling — `git log -S"nand" -- app/models/firmware.rb` is empty. #9 (2022–2023) fixed the generated *commands* from `sf` to `nand`; the image generator never followed.

It asked for `rootfs.squashfs.<soc>`, which no NAND tarball contains — those ship `rootfs.ubi.<soc>`. `TarReader#seek` yields nothing when a member is absent, and the return value was never checked, so the rootfs was dropped and the file served as though complete:

```
$ curl ".../socs/hi3516ev300/download_full_image?flash_size=8&flash_type=nand&fw_release=ultimate"
8388608 bytes
non-0xff spans: 0x0-0x3a000 (U-Boot), 0x50000-0x250000 (valid uImage)
'hsqs' present: False    'UBI#' present: False
```

Same for hi3518ev200. A kernel with nothing to mount.

## What this does

**Takes `rootfs.ubi` on NAND, at NAND offsets.** Kernel at `0x100000`, UBI at `0x400000` — the `mtdpartsubi` layout `256k(boot),768k(wtf),3072k(kernel),-(ubi)` that `uknand`/`urnand` write, read from a real `printenv` in OpenIPC/firmware#695.

**The image ends after the UBI payload, not at the chip boundary.** The parts are 128MiB but the cameras have 64MB of RAM — a chip-sized image could never be staged at the load address to write from. Length is page-aligned so `${filesize}` is a legal `nand write` length.

**Raises `MissingMember` instead of writing a hole.** This is also what keeps SigmaStar and Rockchip out: `firmware/Makefile:140-145` gives them a kernel-less NAND tarball, because the kernel is a volume *inside* `rootfs.ubi` (`ubinize_sigmastar.cfg`, `ubinize_rockchip.cfg`) rather than a partition. No full image can be assembled for them, and now none is served. The controller turns the raise into the existing "This firmware does not exist" notice.

**Reads the archive into a hash rather than seeking twice.** `TarReader#seek` scans forward from the current position, so consecutive seeks only worked while members happened to be in the order asked for.

**Gives `Camera` the NAND geometry it was missing.** `flash_size_hex` was commented out with `??` and fell through to the 8MB NOR default, so the instructions erased `0x800000` of a 128MiB part and `overlay_max_size` went negative, rendering the literal `nand erase 0xD50000 0x-550000` (U-Boot's `simple_strtoul` stops at the `-`, so the size parsed as 0). `overlay_max_size` now refuses a non-positive length, and the by-parts block emits **no overlay erase on NAND at all** — `rootfs_data` is a UBI volume there, so a raw erase at an offset would cut into UBI, and `urnand` already erases that whole partition first.

**`mw.b` pre-fills `staging_size_hex`.** Identical to `flash_size_hex` on NOR; on NAND the flash size is 128MiB and would run off the end of RAM.

**Filenames gain the flash type** (the #58 follow-on). `openipc-<soc>-<release>-<size>mb.bin` was shared across flash types, so one cache file in `public/files/` served them all. Not reachable through the form today, but `download_full_image` takes its params unvalidated. The page now builds the TFTP command through `Firmware.filename_for`, so the command and the download cannot drift apart — previously nothing enforced that.

## Before / after, as the page renders

NAND, hi3516ev300 ultimate:

```diff
-mw.b 0x42000000 0xff 0x800000
-tftpboot 0x42000000 openipc-hi3516ev300-ultimate-8mb.bin && nand erase 0x0 0x800000 && nand write 0x42000000 0x0 0x800000
+mw.b 0x42000000 0xff 0x1800000
+tftpboot 0x42000000 openipc-hi3516ev300-nand-ultimate.bin && nand erase 0x0 0x8000000 && nand write 0x42000000 0x0 ${filesize}
```

and in the by-parts block:

```diff
 run uknand; run urnand
-nand erase 0xD50000 0x-550000
 reset
```

NOR is unchanged apart from the filename:

```diff
-tftpboot 0x82000000 openipc-hi3518ev200-lite-16mb.bin && sf erase 0x0 0x1000000 && sf write 0x82000000 0x0 ${filesize}
+tftpboot 0x82000000 openipc-hi3518ev200-nor-lite-16mb.bin && sf erase 0x0 0x1000000 && sf write 0x82000000 0x0 ${filesize}
```

## Two things to decide

- **The NOR download filename changes.** Anyone following an old permalink gets the new name in both the link and the command, so the flow stays consistent — but files already cached in `public/files/` under the old names are now orphaned and will never be served again. You may want to purge them.
- **`0x1800000` staging is a judgement call.** The largest image the firmware Makefile can produce is `0x400000` + the 16384KB `rootfs.ubi` cap = 20MB exactly. I used 24MB for headroom against a cap bump; it still fits at the load address.

## Verification

Validated on **dev.openipc.org** per `deploy/DEV-VALIDATION.md`, running image
`16a1d9a` (`openipc-deploy dev 16a1d9a0...`, healthy). Everything below is real
execution against the deployed code and the real release tarballs in
`/srv/github-releases`, not a reading of the diff.

### The NAND image, generated for real

```
tarball openipc.hi3516ev300-nand-ultimate.tgz members: uImage.hi3516ev300, rootfs.ubi.hi3516ev300
openipc-hi3516ev300-nand-ultimate.bin
  size            20316160 (0x1360000)
  uImage magic    27051956 at 0x100000
  @0x400000       "UBI#"
  page aligned    true
  < 128MiB        true      fits 64MB RAM  true
```

Fetched through the controller over HTTP as a user would: `http=200`,
`20316160 bytes`, `application/octet-stream`, magic and `UBI#` at the right
offsets. Compare the old output for the same SoC: 8,388,608 bytes, no `hsqs`
and no `UBI#` anywhere in it.

### The refusal, end to end

```
GET /cameras/vendors/sigmastar/socs/ssc338q/download_full_image?flash_type=nand...
  http=302 -> https://dev.openipc.org/     (the "This firmware does not exist" notice)
log: full image unavailable for ssc338q: uImage.ssc338q is not in
     openipc.ssc338q-nand-ultimate.tgz (members: rootfs.ubi.ssc338q)
```

A 302 with the notice, not a 500 and not a kernel-less file. No `rescue_ladder`
hits and no `Completed 500` in the container log.

### NOR regression

Generated images land byte-for-byte where production puts them:

```
hi3518ev200 nor lite 16MB   spans 0x0-0x22000, 0x50000-0x21b000, 0x350000-0x803000
hi3516ev300 nor ultimate    spans 0x0-0x3a000, 0x50000-0x250000, 0x350000-0xb08000  ("hsqs" at 0x350000)
```

`/`, `/supported-hardware/featured` and `/binaries` are byte-identical between
prod and dev once the CSRF token and asset digests are normalised. The SoC page
differs only by its per-request `authenticity_token`. 26 assets on the home
page, 0 non-200.

### Assertions

The 13 unit tests are in the PR but could not be run — the production image does
not ship `test/`. I ran their assertions instead through `rails runner` against
the deployed code: Camera NAND geometry, the NOR values unchanged, filenames
differing by flash type, and `overlay_max_size` raising instead of returning a
negative. All pass.

### Rendered instructions

```
### hi3516ev300 / nand / ultimate
mw.b 0x42000000 0xff 0x1800000
tftpboot 0x42000000 openipc-hi3516ev300-nand-ultimate.bin && nand erase 0x0 0x8000000 && nand write 0x42000000 0x0 ${filesize}
...
run uknand; run urnand
reset                                  <- `nand erase 0xD50000 0x-550000` is gone
```

The page now reads "128MB NAND flash" rather than "128MB NOR flash", and carries
the programmer caveat.

**Still not verified:** that the image boots a real NAND camera. There is no NAND
board in the lab, so this is validated as far as the artifact and the served
bytes, no further. Worth one hardware confirmation before this is advertised as
the primary NAND route; the page still leads with `run uknand; run urnand`.

---

### Review findings (`dbcaec7`)

Both addressed and re-validated on dev. Detail in the review reply; in short:

- **Unbounded allocation** — real, and a regression this branch introduced (the
  original raised on a bad size *before* filling the buffer; splitting the layout
  out moved the raise after it). Now validated up front against `[8, 16, 32]`,
  raising `Firmware::InvalidFlashSize`, rescued by the controller. Measured:
  `?flash_size=999999` returns 302 in 64ms, container memory 117.7 -> 119.5MiB,
  nothing written. All of 8/16/32 still generate exactly.
- **Whole tarball buffered** — applied (single pass, only the two wanted bodies),
  but measured at **110 bytes** saved on the real artifact: an OpenIPC tarball is
  a kernel, a rootfs and two md5sums, so the two needed members are the archive.
  Kept as a robustness tidy-up, not claimed as a memory fix.

Tests grew to 22 to cover both.

### Unrelated bug found while validating — not fixed here

`Camera#overlay_offset` keys on the *variant* (`lite` -> `0x750000`,
`ultimate` -> `0xD50000`), but the real partition table keys on *flash size*:

```
mtdpartsnor8m   rootfs 0x250000..0x750000   rootfs_data 0x750000
mtdpartsnor16m  rootfs 0x350000..0xd50000   rootfs_data 0xd50000
```

Those coincide only for the historical pairings 8M+lite and 16M+ultimate. But
`show.html.erb` forces `lite` when `nor16m` is selected, so every 16MB NOR user
gets the 8MB value. Measured on dev:

```
nor16m / lite: overlay_offset=0x750000 size=0x8b0000
actual 16MB lite image: rootfs occupies 0x350000..0x803000
-> `sf erase 0x750000 0x8b0000` starts 733184 bytes inside the rootfs it just wrote
```

That is in the expert by-parts block, after `run uknor16m; run urnor16m`. It
predates this PR and is a different defect, so I have left it alone rather than
widen the diff. Happy to raise it separately.
