### PR TITLE
Move the blob tree off the block volume onto the system disk

### DIFF
--- a/deploy/RESTORE.md
+++ b/deploy/RESTORE.md
@@ -102,11 +102,18 @@ the blobs will be `root:root` and the container can read them but not create or
 unlink — new uploads and `ActiveStorage::PurgeJob` both fail with `EACCES`:
 
 ```bash
+install -d -o 1000 -g 1000 -m 0755 /srv/www/shared/storage
 chown -R 1000:1000 /srv/www/shared/storage
 ```
 
-Do this **before** cutting traffic over, not after. On ~94k blobs it takes
-several minutes.
+Do this **before** cutting traffic over, not after. On ~94k blobs the recursive
+chown takes several minutes.
+
+`deploy.sh` and `purge-snapshots.sh` both run the `install -d` line themselves
+and refuse to continue if the directory is owned by anyone else, so a rebuilt
+host cannot quietly end up with a root-owned blob tree that Docker created on
+first mount. The recursive chown is still yours to run if you restore blobs
+from somewhere.
 
 ### 6. Host prerequisites
 

--- a/deploy/RESTORE.md
+++ b/deploy/RESTORE.md
@@ -102,7 +102,7 @@ the blobs will be `root:root` and the container can read them but not create or
 unlink — new uploads and `ActiveStorage::PurgeJob` both fail with `EACCES`:
 
 ```bash
-chown -R 1000:1000 /mnt/HC_Volume_103161270/storage
+chown -R 1000:1000 /srv/www/shared/storage
 ```
 
 Do this **before** cutting traffic over, not after. On ~94k blobs it takes
@@ -116,8 +116,9 @@ Only needed on a rebuilt host:
 - `/run/mysqld` bind-mounted into the containers (the socket, not TCP)
 - `/srv/github-releases` — recreated by `~paul/bin/openipc-backup-releases.rb`
   within the hour; the site degrades gracefully until then
-- The Hetzner volume for `storage/`. Blobs are **not** in the backup; the Open
-  Wall will simply be empty until cameras re-upload.
+- `/srv/www/shared/storage` — the blob tree, on the system disk. Blobs are
+  **not** in the backup; the Open Wall will simply be empty until cameras
+  re-upload, so an empty directory owned by uid 1000 is a complete restore.
 
 ## Expected timings
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -47,10 +47,26 @@ env_set() {
 
 target_for() {
   case "$1" in
-    prod) echo "web-prod 3000 PROD_TAG .previous-prod" ;;
-    dev)  echo "web-dev  3001 DEV_TAG  .previous-dev" ;;
+    prod) echo "web-prod 3000 PROD_TAG .previous-prod /srv/www/shared/storage" ;;
+    dev)  echo "web-dev  3001 DEV_TAG  .previous-dev  /srv/www/shared/dev-storage" ;;
     *)    die "unknown target '$1' (expected prod or dev)" ;;
   esac
+}
+
+# The image runs as uid 1000, and the blob tree is a plain host directory since
+# the block volume was retired. If it is missing -- a rebuilt host, a restore --
+# Docker happily creates it root-owned, and then every upload and every purge
+# fails with EACCES while the container still reports healthy. Create it with
+# the right ownership before anything mounts it, and refuse to deploy if it is
+# there but wrong.
+ensure_blob_root() {
+  local root=$1
+  install -d -o 1000 -g 1000 -m 0755 "$root" \
+    || die "cannot create blob root ${root}"
+  local owner
+  owner=$(stat -c '%u:%g' "$root")
+  [ "$owner" = "1000:1000" ] \
+    || die "${root} is owned by ${owner}, expected 1000:1000 — the container runs as uid 1000 and would fail with EACCES"
 }
 
 wait_healthy() {
@@ -67,8 +83,10 @@ wait_healthy() {
 
 do_deploy() {
   local env_name=$1 sha=${2:-latest}
-  read -r service port tag_key prev_file <<<"$(target_for "$env_name")"
+  read -r service port tag_key prev_file blob_root <<<"$(target_for "$env_name")"
   local prev_path="${STATE_DIR}/${prev_file}"
+
+  ensure_blob_root "$blob_root"
 
   local previous
   previous=$(env_get "$tag_key")
@@ -126,8 +144,9 @@ do_deploy() {
 
 do_rollback() {
   local env_name=${1:-prod}
-  read -r service port tag_key prev_file <<<"$(target_for "$env_name")"
+  read -r service port tag_key prev_file blob_root <<<"$(target_for "$env_name")"
   local prev_path="${STATE_DIR}/${prev_file}"
+
   [ -f "$prev_path" ] || die "no previous image recorded for ${env_name} — pass a SHA explicitly"
   local previous current
   previous=$(cat "$prev_path")

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - /run/mysqld:/run/mysqld
       - /srv/github-releases:/srv/github-releases:ro
-      - /mnt/HC_Volume_103161270/storage:/rails/storage
+      - /srv/www/shared/storage:/rails/storage
       - /srv/www/shared/files:/rails/public/files
       - /srv/www/shared/dl:/rails/public/dl:ro
 

--- a/deploy/purge-snapshots.sh
+++ b/deploy/purge-snapshots.sh
@@ -29,7 +29,7 @@ log "purging snapshots past retention (image ${IMAGE_TAG:0:12})"
 docker run --rm \
   --env-file /srv/www/.env.prod \
   -v /run/mysqld:/run/mysqld \
-  -v /mnt/HC_Volume_103161270/storage:/rails/storage \
+  -v /srv/www/shared/storage:/rails/storage \
   "ghcr.io/openipc/website:${IMAGE_TAG}" \
   bundle exec rails runner 'puts "purged #{PurgeImagesJob.new.perform} snapshots"' \
   || { log "FAILED: purge job errored"; exit 1; }
@@ -40,7 +40,7 @@ log "sweeping orphans"
 docker run --rm \
   --env-file /srv/www/.env.prod \
   -v /run/mysqld:/run/mysqld \
-  -v /mnt/HC_Volume_103161270/storage:/rails/storage \
+  -v /srv/www/shared/storage:/rails/storage \
   -e LIMIT=20000 \
   "ghcr.io/openipc/website:${IMAGE_TAG}" \
   bundle exec rails storage:reap 2>&1 | grep -vE '^I, |Disk Storage|^D, ' | tail -12

--- a/deploy/purge-snapshots.sh
+++ b/deploy/purge-snapshots.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 COMPOSE_DIR=/srv/www/deploy-src/deploy
+BLOB_ROOT=/srv/www/shared/storage
 IMAGE_TAG=$(sed -n 's/^PROD_TAG=//p' "${COMPOSE_DIR}/.env" | tail -1)
 
 log() { printf '%s  %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
@@ -29,7 +30,7 @@ log "purging snapshots past retention (image ${IMAGE_TAG:0:12})"
 docker run --rm \
   --env-file /srv/www/.env.prod \
   -v /run/mysqld:/run/mysqld \
-  -v /srv/www/shared/storage:/rails/storage \
+  -v "$BLOB_ROOT":/rails/storage \
   "ghcr.io/openipc/website:${IMAGE_TAG}" \
   bundle exec rails runner 'puts "purged #{PurgeImagesJob.new.perform} snapshots"' \
   || { log "FAILED: purge job errored"; exit 1; }
@@ -40,9 +41,22 @@ log "sweeping orphans"
 docker run --rm \
   --env-file /srv/www/.env.prod \
   -v /run/mysqld:/run/mysqld \
-  -v /srv/www/shared/storage:/rails/storage \
+  -v "$BLOB_ROOT":/rails/storage \
   -e LIMIT=20000 \
   "ghcr.io/openipc/website:${IMAGE_TAG}" \
   bundle exec rails storage:reap 2>&1 | grep -vE '^I, |Disk Storage|^D, ' | tail -12
+
+# ActiveStorage's DiskService creates key[0..1]/key[2..3]/ shard directories on
+# write and never removes them on purge, so every snapshot deleted here leaves
+# two behind. Left alone since 2023 they reached 1.04 million directories --
+# 4.2 GB of nothing, and slow enough to walk that measuring the tree took
+# minutes. storage:reap cannot see them: it works from database rows, and these
+# have none. Two passes, because emptying a leaf makes its parent empty.
+log "removing empty shard directories"
+before=$(find "$BLOB_ROOT" -mindepth 1 -type d | wc -l)
+find "$BLOB_ROOT" -mindepth 1 -type d -empty -delete
+find "$BLOB_ROOT" -mindepth 1 -type d -empty -delete
+after=$(find "$BLOB_ROOT" -mindepth 1 -type d | wc -l)
+log "shard directories: ${before} -> ${after}"
 
 log "purge complete"

--- a/deploy/purge-snapshots.sh
+++ b/deploy/purge-snapshots.sh
@@ -22,6 +22,15 @@ log() { printf '%s  %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
 
 [ -n "$IMAGE_TAG" ] || { log "FAILED: no PROD_TAG in ${COMPOSE_DIR}/.env"; exit 1; }
 
+# Cron reaches this before a deploy does on a rebuilt host. Docker would create
+# a missing bind-mount source root-owned, and the container -- which runs as uid
+# 1000 -- would then fail every write with EACCES.
+install -d -o 1000 -g 1000 -m 0755 "$BLOB_ROOT" \
+  || { log "FAILED: cannot create ${BLOB_ROOT}"; exit 1; }
+owner=$(stat -c '%u:%g' "$BLOB_ROOT")
+[ "$owner" = "1000:1000" ] \
+  || { log "FAILED: ${BLOB_ROOT} is owned by ${owner}, expected 1000:1000"; exit 1; }
+
 log "purging snapshots past retention (image ${IMAGE_TAG:0:12})"
 
 # A one-off container rather than `docker exec` into web-prod: purging is IO


### PR DESCRIPTION
The 100 GB Hetzner volume attached to `webber-eu` held 13 GB, and **4.2 GB of that was empty directories**.

ActiveStorage's `DiskService` creates `key[0..1]/key[2..3]/` shard directories on write and never removes them on purge, so every snapshot deleted since 2023 left two behind. `df -i` reported **1,168,972 inodes** against ~110k real files; sampling 20 of the 1,296 top-level shards found 16,079 directories of which 16,033 were empty. `storage:reap` cannot reclaim these — it works from database rows and only ever deletes files.

What the volume actually holds:

| Tenant | On disk | Real data |
|---|---|---|
| `github-releases` | 4.3 GB | re-downloaded hourly from GitHub, excluded from the backup |
| `github-mirror` | 3.6 GB | git mirrors of public repos |
| `storage` | ~5 GB | **0.34 GB** of live blobs on a two-day retention |

The system disk has 52 GB free, so the volume buys nothing but a line on the invoice.

## What changes here

`storage/` was the only path pinned to the mount point. It moves to `/srv/www/shared/storage`, beside `dev-storage`, `files` and `dl`. The purge and reap containers bind-mount the same path and move with it.

`/srv/github-releases` and `/srv/github-mirror` are host symlinks that become real directories, so nothing in this repo referred to them by mount point.

## Host side

The data has already been copied and the empty directories swept. Once this merges, `/srv/www/deploy-src` gets a `git pull` and prod restarts on the new mount; the volume stays attached and untouched as a rollback until it is detached from the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFwmYHCbci2esgc8AMmzJR