### PR TITLE
Stop the release mirror re-downloading 100 GB a day onto itself

### DIFF
--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -34,11 +34,22 @@
 require 'digest'
 require 'fileutils'
 require 'github_api'
+require 'json'
 require 'open3'
 
 ROOT = '/srv/github-releases'
 LOCK = '/run/lock/openipc-mirror-releases.lock'
 TMP_PREFIX = '.tmp-mirror-'
+
+# What we last put on disk, as {name => {size, digest}}. Without it, telling a
+# rebuilt asset from the one already here means hashing 4.3 GB every hour.
+STATE_FILE = '.mirror-state.json'
+
+# Asset names come from the API and are pasted straight into a path. Anything
+# with a slash, or a leading dot, is refused rather than sanitised -- a plain
+# filename is the only thing this should ever see, and the leading-dot rule
+# also stops an asset colliding with the state file or the size manifests.
+SAFE_NAME = /\A[A-Za-z0-9][A-Za-z0-9._+-]*\z/.freeze
 
 # One page of releases, newest first. The rolling `nightly` and `latest` tags
 # sort first and carry the current build; older dated nightlies behind them
@@ -54,6 +65,7 @@ end
 # Non-blocking, so an overrun run is skipped rather than queued. Queuing would
 # reproduce the overlap this exists to prevent, one hour later.
 def with_lock
+  FileUtils.mkdir_p(File.dirname(LOCK))
   lock = File.open(LOCK, File::CREAT | File::RDWR, 0o644)
   unless lock.flock(File::LOCK_EX | File::LOCK_NB)
     log 'previous run still going, skipping this hour'
@@ -63,6 +75,23 @@ def with_lock
 ensure
   lock&.flock(File::LOCK_UN)
   lock&.close
+end
+
+def load_state
+  path = File.join(ROOT, STATE_FILE)
+  return {} unless File.exist?(path)
+
+  JSON.parse(File.read(path))
+rescue JSON::ParserError
+  log 'state file unreadable, rebuilding it as files are checked'
+  {}
+end
+
+def save_state(state)
+  path = File.join(ROOT, STATE_FILE)
+  tmp = "#{path}.tmp"
+  File.write(tmp, JSON.pretty_generate(state))
+  File.rename(tmp, path)
 end
 
 # The newest release that publishes each asset name wins. `list` returns
@@ -78,6 +107,11 @@ def newest_assets
       next if name.include?('sdk')
       next if chosen.key?(name)
 
+      unless SAFE_NAME.match?(name)
+        log "  refusing #{name.inspect} from #{release.tag_name}: not a plain filename"
+        next
+      end
+
       chosen[name] = {
         name: name,
         url: asset['browser_download_url'],
@@ -90,28 +124,36 @@ def newest_assets
   chosen
 end
 
-# A local file is current when it is the size the API reports. Size alone is
-# enough to decide *whether* to fetch; the digest below decides whether to keep
-# what arrived. A zero-byte local file is never current -- that is what heals
-# the holes the old script left behind.
-def current?(path, asset)
+# A local file is current when it is both the size and the content the API
+# reports. Size is checked first because it is free and settles most cases.
+#
+# The digest of what we last wrote is remembered rather than recomputed, so a
+# quiet run reads no file data at all. The cost is that a file altered outside
+# this script, to exactly the same length, is not noticed -- delete the state
+# file to force everything to be re-hashed.
+def current?(path, asset, state)
   return false unless File.exist?(path)
 
   size = File.size(path)
-  size.positive? && size == asset[:size]
-end
+  return false unless size.positive? && size == asset[:size]
 
-def digest_ok?(path, asset)
   expected = asset[:digest]
-  return true if expected.nil? || !expected.start_with?('sha256:')
+  return true unless expected&.start_with?('sha256:')
 
-  "sha256:#{Digest::SHA256.file(path).hexdigest}" == expected
+  remembered = state[asset[:name]]
+  return remembered['digest'] == expected if remembered && remembered['size'] == size
+
+  # Never hashed, or hashed when the file was a different length: pay for one
+  # read now and remember it, so later runs cost nothing.
+  actual = "sha256:#{Digest::SHA256.file(path).hexdigest}"
+  state[asset[:name]] = { 'size' => size, 'digest' => actual }
+  actual == expected
 end
 
 # Download beside the target and rename into place. The rename is atomic within
 # the directory, so no reader -- and no rsync taking a migration snapshot --
 # ever sees a partial file under the real name.
-def fetch(asset)
+def fetch(asset, state)
   dest = File.join(ROOT, asset[:name])
   tmp = File.join(ROOT, "#{TMP_PREFIX}#{asset[:name]}")
 
@@ -124,13 +166,16 @@ def fetch(asset)
     return false
   end
 
-  unless digest_ok?(tmp, asset)
+  actual = "sha256:#{Digest::SHA256.file(tmp).hexdigest}"
+  expected = asset[:digest]
+  if expected&.start_with?('sha256:') && actual != expected
     log "  FAILED checksum #{asset[:name]} (#{asset[:release]}), keeping the old copy"
     FileUtils.rm_f(tmp)
     return false
   end
 
   File.rename(tmp, dest)
+  state[asset[:name]] = { 'size' => File.size(dest), 'digest' => actual }
   true
 end
 
@@ -150,6 +195,11 @@ def member_size(tarball, needle)
   nil
 end
 
+def manifest_missing?(filename)
+  path = File.join(ROOT, filename)
+  !File.exist?(path) || File.size(path).zero?
+end
+
 def write_manifest(filename, needle)
   path = File.join(ROOT, filename)
   tmp = "#{path}.tmp"
@@ -162,9 +212,10 @@ def write_manifest(filename, needle)
   log "  wrote #{filename} (#{File.readlines(path).size} entries)"
 end
 
+MANIFESTS = { '.rootfs.sizes' => 'rootfs', '.kernel.sizes' => 'uImage' }.freeze
+
 with_lock do
   FileUtils.mkdir_p(ROOT)
-  Dir.chdir(ROOT)
 
   # Debris from a run that was killed mid-download, as both overlapping runs
   # were on 2026-08-23.
@@ -174,8 +225,9 @@ with_lock do
     FileUtils.rm_f(stale)
   end
 
+  state = load_state
   assets = newest_assets
-  wanted = assets.values.reject { |a| current?(File.join(ROOT, a[:name]), a) }
+  wanted = assets.values.reject { |a| current?(File.join(ROOT, a[:name]), a, state) }
   log "#{assets.size} assets published, #{wanted.size} to fetch"
 
   if DRY_RUN
@@ -184,14 +236,21 @@ with_lock do
     exit 0
   end
 
-  fetched = wanted.count { |a| fetch(a) }
+  fetched = wanted.count { |a| fetch(a, state) }
   log "fetched #{fetched} of #{wanted.size}"
 
-  # Only when something moved: rebuilding these means listing every tarball,
-  # which is the expensive part of a run where nothing changed.
-  if fetched.positive?
-    write_manifest('.rootfs.sizes', 'rootfs')
-    write_manifest('.kernel.sizes', 'uImage')
+  # Forget assets the org no longer publishes, so the state file tracks the
+  # release set rather than growing forever.
+  save_state(state.slice(*assets.keys))
+
+  # Rebuilding a manifest means listing every tarball, which is the expensive
+  # part of a run where nothing changed -- but a manifest that is missing or
+  # empty has to be rebuilt whether or not anything was downloaded, or the
+  # binaries page stays broken until the next night's build happens to land.
+  missing = MANIFESTS.keys.select { |m| manifest_missing?(m) }
+  if fetched.positive? || !missing.empty?
+    log "rebuilding manifests (#{missing.empty? ? 'assets changed' : "#{missing.join(', ')} missing"})"
+    MANIFESTS.each { |filename, needle| write_manifest(filename, needle) }
   else
     log 'nothing changed, manifests left alone'
   end

--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -1,0 +1,200 @@
+#!/usr/bin/ruby
+# frozen_string_literal: true
+
+# Mirror the OpenIPC firmware release assets into /srv/github-releases -- the
+# directory Soc::RELEASES_ROOT reads and Firmware#generate assembles images
+# from.
+#
+#   mirror-releases.rb            normal run
+#   mirror-releases.rb --dry-run  report what would change, download nothing
+#
+# Cron:  5 * * * *  paul  /usr/local/sbin/openipc-mirror-releases
+#
+# This replaces ~paul/bin/openipc-backup-releases.rb, which unlinked and
+# re-downloaded every asset on every run: about 4 GB an hour, ~100 GB a day,
+# for a set that changes once a night. Three consequences, all observed on
+# 2026-08-23:
+#
+#   * A run took longer than the hour between runs, so instances overlapped.
+#     Two were live at once during the block-volume migration.
+#   * wget wrote straight to the final filename, so every asset spent a moment
+#     as a zero-byte hole. A copy taken during that moment captured a
+#     zero-byte tarball -- that is how openipc.ssc378de-nor-lite.tgz was lost.
+#   * The asset URL and filename were interpolated into a shell command.
+#
+# It also mirrored the wrong build. Assets were written in release order with
+# each overwriting the last, so the *oldest* release on the page won and the
+# mirror served firmware a month or two stale. Assets now come from the newest
+# release that carries them.
+#
+# Beware `asset.size`. These are Hashie mashes, so `.size` is Hash#size and
+# returns the key count -- 14, identically, for every asset ever published.
+# The byte size is `asset['size']`.
+
+require 'digest'
+require 'fileutils'
+require 'github_api'
+require 'open3'
+
+ROOT = '/srv/github-releases'
+LOCK = '/run/lock/openipc-mirror-releases.lock'
+TMP_PREFIX = '.tmp-mirror-'
+
+# One page of releases, newest first. The rolling `nightly` and `latest` tags
+# sort first and carry the current build; older dated nightlies behind them
+# fill in assets those two happen not to publish.
+RELEASES_PER_PAGE = 30
+
+DRY_RUN = ARGV.include?('--dry-run')
+
+def log(message)
+  warn format('%s  %s', Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'), message)
+end
+
+# Non-blocking, so an overrun run is skipped rather than queued. Queuing would
+# reproduce the overlap this exists to prevent, one hour later.
+def with_lock
+  lock = File.open(LOCK, File::CREAT | File::RDWR, 0o644)
+  unless lock.flock(File::LOCK_EX | File::LOCK_NB)
+    log 'previous run still going, skipping this hour'
+    exit 0
+  end
+  yield
+ensure
+  lock&.flock(File::LOCK_UN)
+  lock&.close
+end
+
+# The newest release that publishes each asset name wins. `list` returns
+# releases newest-first, so the first sighting of a name is the freshest.
+def newest_assets
+  github = Github.new
+  releases = github.repos.releases.list('openipc', 'firmware',
+                                        per_page: RELEASES_PER_PAGE)
+  chosen = {}
+  releases.each do |release|
+    release.assets.each do |asset|
+      name = asset['name']
+      next if name.include?('sdk')
+      next if chosen.key?(name)
+
+      chosen[name] = {
+        name: name,
+        url: asset['browser_download_url'],
+        size: asset['size'],
+        digest: asset['digest'],
+        release: release.tag_name
+      }
+    end
+  end
+  chosen
+end
+
+# A local file is current when it is the size the API reports. Size alone is
+# enough to decide *whether* to fetch; the digest below decides whether to keep
+# what arrived. A zero-byte local file is never current -- that is what heals
+# the holes the old script left behind.
+def current?(path, asset)
+  return false unless File.exist?(path)
+
+  size = File.size(path)
+  size.positive? && size == asset[:size]
+end
+
+def digest_ok?(path, asset)
+  expected = asset[:digest]
+  return true if expected.nil? || !expected.start_with?('sha256:')
+
+  "sha256:#{Digest::SHA256.file(path).hexdigest}" == expected
+end
+
+# Download beside the target and rename into place. The rename is atomic within
+# the directory, so no reader -- and no rsync taking a migration snapshot --
+# ever sees a partial file under the real name.
+def fetch(asset)
+  dest = File.join(ROOT, asset[:name])
+  tmp = File.join(ROOT, "#{TMP_PREFIX}#{asset[:name]}")
+
+  # No shell: asset names and URLs come from the API and are not ours to trust.
+  ok = system('curl', '-fsSL', '--retry', '3', '--retry-delay', '2',
+              '--max-time', '600', '-o', tmp, asset[:url])
+  unless ok
+    log "  FAILED download #{asset[:name]} (#{asset[:release]})"
+    FileUtils.rm_f(tmp)
+    return false
+  end
+
+  unless digest_ok?(tmp, asset)
+    log "  FAILED checksum #{asset[:name]} (#{asset[:release]}), keeping the old copy"
+    FileUtils.rm_f(tmp)
+    return false
+  end
+
+  File.rename(tmp, dest)
+  true
+end
+
+# `tar -tv` prints size in the third field. Members are matched the way the
+# original did, so .rootfs.sizes keeps the shape BinariesController parses:
+# "<tarball> <bytes>", and an absent member leaves the size blank (nil.to_i).
+def member_size(tarball, needle)
+  out, status = Open3.capture2('tar', '-tvf', tarball)
+  return nil unless status.success?
+
+  out.each_line do |line|
+    next unless line.include?(needle)
+    next if line.include?('md5sum')
+
+    return line.split[2]
+  end
+  nil
+end
+
+def write_manifest(filename, needle)
+  path = File.join(ROOT, filename)
+  tmp = "#{path}.tmp"
+  File.open(tmp, 'w') do |f|
+    Dir.glob(File.join(ROOT, 'openipc.*.tgz')).sort.each do |tarball|
+      f.puts "#{File.basename(tarball)} #{member_size(tarball, needle)}"
+    end
+  end
+  File.rename(tmp, path)
+  log "  wrote #{filename} (#{File.readlines(path).size} entries)"
+end
+
+with_lock do
+  FileUtils.mkdir_p(ROOT)
+  Dir.chdir(ROOT)
+
+  # Debris from a run that was killed mid-download, as both overlapping runs
+  # were on 2026-08-23.
+  stale = Dir.glob(File.join(ROOT, "#{TMP_PREFIX}*"))
+  unless stale.empty?
+    log "clearing #{stale.size} temporary file(s) from an interrupted run"
+    FileUtils.rm_f(stale)
+  end
+
+  assets = newest_assets
+  wanted = assets.values.reject { |a| current?(File.join(ROOT, a[:name]), a) }
+  log "#{assets.size} assets published, #{wanted.size} to fetch"
+
+  if DRY_RUN
+    wanted.each { |a| log "  would fetch #{a[:name]} (#{a[:size]} bytes, #{a[:release]})" }
+    log 'dry run, nothing written'
+    exit 0
+  end
+
+  fetched = wanted.count { |a| fetch(a) }
+  log "fetched #{fetched} of #{wanted.size}"
+
+  # Only when something moved: rebuilding these means listing every tarball,
+  # which is the expensive part of a run where nothing changed.
+  if fetched.positive?
+    write_manifest('.rootfs.sizes', 'rootfs')
+    write_manifest('.kernel.sizes', 'uImage')
+  else
+    log 'nothing changed, manifests left alone'
+  end
+
+  log 'done'
+end

--- a/deploy/mirror-repos.rb
+++ b/deploy/mirror-repos.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/ruby
+# frozen_string_literal: true
+
+# Keep a local clone of every OpenIPC repository under /srv/github-mirror.
+# Nothing serves this -- it is a copy held against losing the GitHub org.
+#
+# Cron:  0 * * * *  paul  /usr/local/sbin/openipc-mirror-repos
+#
+# This replaces ~paul/bin/openipc-backup.rb. The fetching is unchanged and
+# already incremental; what it lacked was a guard against lapping itself, the
+# same fault that let two release-mirror runs overlap and truncate a tarball
+# during the 2026-08-23 volume migration.
+#
+# Three lines were dropped in the move. Two piped git output into `xargs echo
+# git ...`, which prints a command rather than running one, so they had no
+# effect beyond a fork per repository per hour. Their intent -- create local
+# tracking branches for every remote branch, and delete branches gone upstream
+# -- is not reinstated here, because turning dead code live is a behaviour
+# change and belongs in its own review. The third was a bare `git rebase`,
+# which has no upstream to rebase onto in a fresh clone and did nothing but
+# fill the cron log with "fatal: invalid upstream 'refs/remotes/origin/master'"
+# once per repository per hour; `git pull --all` below does the real work.
+#
+# Only the first page of the repository listing is fetched, as before -- 30
+# repositories, against the 35 directories that have accumulated on disk. The
+# rest are no longer refreshed. Widening that is a separate decision: it means
+# cloning every repository the org has ever published.
+
+require 'fileutils'
+require 'github_api'
+
+ROOT = '/srv/github-mirror'
+LOCK = '/run/lock/openipc-mirror-repos.lock'
+
+def log(message)
+  warn format('%s  %s', Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'), message)
+end
+
+# Non-blocking: skip this hour rather than queue behind the run in progress.
+def with_lock
+  lock = File.open(LOCK, File::CREAT | File::RDWR, 0o644)
+  unless lock.flock(File::LOCK_EX | File::LOCK_NB)
+    log 'previous run still going, skipping this hour'
+    exit 0
+  end
+  yield
+ensure
+  lock&.flock(File::LOCK_UN)
+  lock&.close
+end
+
+with_lock do
+  FileUtils.mkdir_p(ROOT)
+  github = Github.new
+  repos = github.repos.list(user: 'openipc')
+  log "#{repos.size} repositories listed"
+
+  cloned = 0
+  updated = 0
+  failed = []
+
+  repos.each do |repo|
+    path = File.join(ROOT, repo.name)
+
+    unless Dir.exist?(path)
+      # No shell: repository names and URLs come from the API.
+      if system('git', 'clone', '--quiet', repo.clone_url, path)
+        cloned += 1
+      else
+        failed << "#{repo.name} (clone)"
+        next
+      end
+    end
+
+    ok = system('git', '-C', path, 'fetch', '--prune', '--quiet') &&
+         system('git', '-C', path, 'pull', '--all', '--quiet')
+    ok ? updated += 1 : failed << repo.name
+  end
+
+  log "cloned #{cloned}, updated #{updated}"
+  log "failed: #{failed.join(', ')}" unless failed.empty?
+  log 'done'
+end

--- a/deploy/mirror-repos.rb
+++ b/deploy/mirror-repos.rb
@@ -38,6 +38,7 @@ end
 
 # Non-blocking: skip this hour rather than queue behind the run in progress.
 def with_lock
+  FileUtils.mkdir_p(File.dirname(LOCK))
   lock = File.open(LOCK, File::CREAT | File::RDWR, 0o644)
   unless lock.flock(File::LOCK_EX | File::LOCK_NB)
     log 'previous run still going, skipping this hour'


### PR DESCRIPTION
Found while migrating the block volume: `~paul/bin/openipc-backup-releases.rb` unlinks and re-downloads **every** release asset on **every** hourly run — about 4 GB an hour, ~100 GB a day, for a set that changes once a night. `/proc/diskstats` showed 44 GB written to the volume in 2h33m of uptime against 1.5 GB to the system disk.

Three consequences, all observed on 2026-08-23:

- **It laps itself.** A run takes over an hour, so instances overlap. The 18:05 and 19:05 runs were both live during the migration.
- **It corrupts.** `wget` writes straight to the final filename, so every asset spends a moment as a zero-byte hole. A copy taken during that moment captured a zero-byte `openipc.ssc378de-nor-lite.tgz` — and the ssc378de full-image download had been failing on the live site ever since, because the same hole existed on disk before the migration.
- **It mirrors the wrong build.** Assets were written in release order with each overwriting the last, so the *oldest* release on the page won and the site served firmware built around 18 June.

## What the replacement does

| | before | after |
|---|---|---|
| overlap | none | non-blocking `flock`, an overrun run is skipped not queued |
| downloads | all ~4 GB, hourly | only assets whose local size ≠ the API's — 103 of 495 on the first run, then near-zero |
| writes | `wget` → final filename | `curl` → `.tmp-`, verify `sha256` from the API's `digest` field, atomic `rename` |
| shell | URL and filename interpolated into `%x[wget ...]` | passed as argv, no shell |
| build selected | oldest release on the page | newest release that publishes the asset |
| manifests | `.rootfs.sizes`/`.kernel.sizes` rebuilt every run | only when something actually changed |

`mirror-repos.rb` is the repo-mirror script with the same lock added; its `git fetch` was already incremental. Three dead lines went with it — two `xargs echo git ...` no-ops and a bare `git rebase` that only ever emitted `fatal: invalid upstream` once per repo per hour — each documented in place.

## One trap worth knowing

These are Hashie mashes, so `asset.size` resolves to `Hash#size` and returns **14** — the key count — for every asset ever published. A size-comparison guard written with `asset.size` would compare every local file against the constant 14. The byte size is `asset['size']`.

## Deployment

Symlinked into `/usr/local/sbin` following the existing pattern, with paul's crontab pointed at them. The originals are kept beside them as `.superseded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFwmYHCbci2esgc8AMmzJR