### PR TITLE
Run the test suite in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
       RAILS_ENV: test
       OPENIPC_DATABASE_HOST: 127.0.0.1
       OPENIPC_DATABASE_PORT: 3306
+      # error_highlight is a development-group gem, and the version in
+      # Gemfile.lock needs Ruby >= 3.2 while this app is on 3.1. The image never
+      # hit it because it excludes development:test entirely; here we need the
+      # test group but not development.
+      BUNDLE_WITHOUT: development
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,17 +49,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Matches the Dockerfile, so a gem that compiles there compiles here.
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.1.7'
-          bundler-cache: true
-
+      # Before setup-ruby, because bundler-cache runs bundle install and mysql2
+      # needs libmysqlclient headers to compile. It passes today only because
+      # the hosted runner happens to ship them; the Dockerfile installs the OS
+      # packages first for the same reason and this now matches that order.
       - name: Install libraries the gems bind to
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             default-libmysqlclient-dev libvips42 libheif1
+
+      # Matches the Dockerfile, so a gem that compiles there compiles here.
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.7'
+          bundler-cache: true
 
       # database.yml authenticates as www/www. Grant it globally rather than on
       # one schema: test_helper parallelizes, and each worker creates its own

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,59 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  # Runs alongside build rather than gating it: a broken test should not stop an
+  # image existing for a branch, but it must stop the merge. Add "test" to the
+  # required status checks on master once this has been green for a few runs.
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:11.8
+        env:
+          MARIADB_ROOT_PASSWORD: root
+        ports: ['3306:3306']
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s --health-timeout=5s --health-retries=10
+
+    env:
+      RAILS_ENV: test
+      OPENIPC_DATABASE_HOST: 127.0.0.1
+      OPENIPC_DATABASE_PORT: 3306
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Matches the Dockerfile, so a gem that compiles there compiles here.
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1.7'
+          bundler-cache: true
+
+      - name: Install libraries the gems bind to
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            default-libmysqlclient-dev libvips42 libheif1
+
+      # database.yml authenticates as www/www. Grant it globally rather than on
+      # one schema: test_helper parallelizes, and each worker creates its own
+      # openipc_test-N database.
+      - name: Create the test database user
+        run: |
+          mysql -h 127.0.0.1 -P 3306 -uroot -proot -e "
+            CREATE USER IF NOT EXISTS 'www'@'%' IDENTIFIED BY 'www';
+            GRANT ALL PRIVILEGES ON *.* TO 'www'@'%' WITH GRANT OPTION;
+            FLUSH PRIVILEGES;"
+
+      # Load db/schema.rb directly. The usual flow regenerates the test database
+      # from development, which does not exist here.
+      - name: Prepare schema
+        run: bin/rails db:test:prepare
+
+      - name: Run tests
+        run: bin/rails test
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,16 @@ jobs:
             GRANT ALL PRIVILEGES ON *.* TO 'www'@'%' WITH GRANT OPTION;
             FLUSH PRIVILEGES;"
 
-      # db:test:prepare expects the database to exist; create it explicitly and
-      # load db/schema.rb. The usual flow regenerates the test database from
-      # development, which does not exist here.
+      # Create explicitly (db:test:prepare assumes the database exists), load
+      # db/schema.rb, then migrate.
+      #
+      # The migrate is not redundant: db/schema.rb is pinned at
+      # 2022_08_06_130659 while db/migrate/ runs to 2023_05_07_193639, so five
+      # migrations were never dumped into it and loading the schema alone leaves
+      # the suite refusing to start with "Migrations are pending". Regenerating
+      # schema.rb is the real fix and belongs in its own change.
       - name: Prepare schema
-        run: bin/rails db:create db:schema:load
+        run: bin/rails db:create db:schema:load db:migrate
 
       - name: Run tests
         run: bin/rails test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,10 +71,11 @@ jobs:
             GRANT ALL PRIVILEGES ON *.* TO 'www'@'%' WITH GRANT OPTION;
             FLUSH PRIVILEGES;"
 
-      # Load db/schema.rb directly. The usual flow regenerates the test database
-      # from development, which does not exist here.
+      # db:test:prepare expects the database to exist; create it explicitly and
+      # load db/schema.rb. The usual flow regenerates the test database from
+      # development, which does not exist here.
       - name: Prepare schema
-        run: bin/rails db:test:prepare
+        run: bin/rails db:create db:schema:load
 
       - name: Run tests
         run: bin/rails test

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,15 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 16 } %>
   username: www
   password: www
+<%- if ENV["OPENIPC_DATABASE_HOST"].present? -%>
+  # CI and any other host that reaches MariaDB over TCP rather than the local
+  # socket. The socket below is unreachable from a service container, which is
+  # why the suite could not run in CI at all.
+  host: <%= ENV["OPENIPC_DATABASE_HOST"] %>
+  port: <%= ENV.fetch("OPENIPC_DATABASE_PORT") { 3306 } %>
+<%- else -%>
   socket: /run/mysqld/mysqld.sock
+<%- end -%>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,15 +15,15 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 16 } %>
   username: www
   password: www
-<%- if ENV["OPENIPC_DATABASE_HOST"].present? -%>
+<% if ENV["OPENIPC_DATABASE_HOST"].present? %>
   # CI and any other host that reaches MariaDB over TCP rather than the local
   # socket. The socket below is unreachable from a service container, which is
   # why the suite could not run in CI at all.
   host: <%= ENV["OPENIPC_DATABASE_HOST"] %>
   port: <%= ENV.fetch("OPENIPC_DATABASE_PORT") { 3306 } %>
-<%- else -%>
+<% else %>
   socket: /run/mysqld/mysqld.sock
-<%- end -%>
+<% end %>
 
 development:
   <<: *default

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,11 +1,15 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# Devise requires email and encrypted_password. `email` carries a unique index
+# with a "" default, so every record needs a distinct one -- the generated
+# `one: {}` / `two: {}` stubs both defaulted to "" and collided, which failed
+# fixture loading for the whole suite.
+#
+# encrypted_password is a bcrypt digest of "password"; it only has to be a
+# well-formed digest, no test authenticates with it.
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  email: admin-one@example.com
+  encrypted_password: "$2a$12$K8GpaCcQ1pQVvKF5nkHhIuqnHRHFqLLKrJ0N3PJgZ3wLb1sYyLKGe"
+
+two:
+  email: admin-two@example.com
+  encrypted_password: "$2a$12$K8GpaCcQ1pQVvKF5nkHhIuqnHRHFqLLKrJ0N3PJgZ3wLb1sYyLKGe"

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -162,8 +162,13 @@ class FirmwareTest < ActiveSupport::TestCase
                members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI })
     fw.generate
 
-    assert_equal 0x400000 + UBI.bytesize, File.size(fw.filepath),
+    # Sized from the payload, then rounded up to a whole page: U-Boot's
+    # `nand write` rejects a length that is not a multiple of the page size,
+    # and the generated image is written with ${filesize}.
+    expected = ((0x400000 + UBI.bytesize) + 2047) / 2048 * 2048
+    assert_equal expected, File.size(fw.filepath),
                  'a NAND image is sized from its payload, never from the parameter'
+    assert_equal 0, File.size(fw.filepath) % 2048, 'image length must be page aligned'
   end
 
   test 'only the members needed are read into memory' do
@@ -175,7 +180,14 @@ class FirmwareTest < ActiveSupport::TestCase
 
     # The unrelated member must not appear anywhere in the assembled image.
     assert_equal UBI, IO.binread(fw.filepath)[0x400000, UBI.bytesize]
-    assert File.size(fw.filepath) < big.bytesize, 'an unwanted member leaked into the image'
+
+    # Size is the tell: it is fixed by the rootfs offset plus the UBI payload,
+    # so anything else finding its way in would move it. Comparing against
+    # big.bytesize cannot work -- the rootfs offset alone is 4 MiB, so a NAND
+    # image is always at least that large.
+    expected = ((0x400000 + UBI.bytesize) + 2047) / 2048 * 2048
+    assert_equal expected, File.size(fw.filepath), 'an unwanted member leaked into the image'
+    refute_includes IO.binread(fw.filepath), big[0, 4096], 'unwanted member content is present'
   end
 
   test 'the missing-member error still names what the tarball does hold' do

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -172,7 +172,10 @@ class FirmwareTest < ActiveSupport::TestCase
   end
 
   test 'only the members needed are read into memory' do
-    big = "\x00".b * (4 * 1024 * 1024)
+    # A distinctive sentinel, not a run of NULs: a firmware blob can legitimately
+    # contain long zero runs, so searching for those would fail on a clean image.
+    sentinel = 'UNWANTED-MEMBER-DO-NOT-COPY'.b
+    big = sentinel * (4 * 1024 * 1024 / sentinel.bytesize)
     fw = build(model: 'hi3516ev300', vendor: 'HiSilicon', flash_type: 'nand', size: 128,
                members: { 'uImage.hi3516ev300' => KERNEL, 'rootfs.ubi.hi3516ev300' => UBI,
                           'unrelated.blob' => big })
@@ -187,7 +190,7 @@ class FirmwareTest < ActiveSupport::TestCase
     # image is always at least that large.
     expected = ((0x400000 + UBI.bytesize) + 2047) / 2048 * 2048
     assert_equal expected, File.size(fw.filepath), 'an unwanted member leaked into the image'
-    refute_includes IO.binread(fw.filepath), big[0, 4096], 'unwanted member content is present'
+    refute_includes IO.binread(fw.filepath), sentinel, 'unwanted member content is present'
   end
 
   test 'the missing-member error still names what the tarball does hold' do


### PR DESCRIPTION
Closes #66.

The workflow only built the image, so every test in this repository was dead weight — including the ~22 cases #59 added. They could not run in the container either, since `.dockerignore` excludes `test/`. They executed nowhere, and a green check on a PR adding tests read as "the tests pass".

## What it took

**`config/database.yml` hardcoded a Unix socket** in its shared `default:` block, unreachable from a service container. The socket is now used unless `OPENIPC_DATABASE_HOST` is set, so production keeps the socket and CI gets TCP.

**Rails parses `database.yml` with plain ERB**, no trim mode, so `<%- -%>` is a syntax error — it broke the image build until corrected to `<% %>`.

**`error_highlight` in `Gemfile.lock` needs Ruby ≥ 3.2** and this app is on 3.1. It is development-group only; the image never hit it because `BUNDLE_WITHOUT=development:test` excludes both. CI needs the test group but not development.

**`db/schema.rb` is pinned at `2022_08_06_130659`** while `db/migrate/` runs to `2023_05_07_193639`, so five migrations were never dumped into it and the suite refused to start with "Migrations are pending". The job runs `db:migrate` after the load. Regenerating `schema.rb` is the real fix and deserves its own change — raised separately.

## Three pre-existing bugs it immediately found

**`test/fixtures/admins.yml` still held the generated `one: {}` / `two: {}` stubs.** `admins.email` is `NOT NULL` with a `""` default and a unique index, so both records collided on the empty string and *every* test failed during fixture loading:

```
Mysql2::Error: Duplicate entry  for key index_admins_on_email
```

Broken since the Devise model was added in 2022.

**Two assertions in #59 that could never have held.** One expected the unaligned NAND length where `generate` page-aligns — the code is right, since `nand write` rejects a non-page-multiple length and the image is written with `${filesize}`:

```
Expected: 4206596
  Actual: 4208640      (rounded up to the next 2048)
```

The other asserted the image is smaller than a 4 MiB unwanted member, which is impossible — the rootfs offset alone is 4 MiB, so every NAND image is at least that large. Replaced with an exact size assertion, which is what actually detects a leak.

## Result

```
22 runs, 67 assertions, 0 failures, 0 errors, 0 skips
```

The `test` job runs alongside `build` rather than gating it: a broken test should not stop an image existing for a branch, but it should stop a merge. Suggest adding `test` to the required status checks on `master` once it has been green for a few runs — happy to do that now if you prefer.