### PR TITLE
Answer 404 for a record that is not there, not a redirect home

### DIFF
--- a/app/controllers/concerns/rescue_handler.rb
+++ b/app/controllers/concerns/rescue_handler.rb
@@ -11,13 +11,16 @@ module RescueHandler
 
   def rescue_ladder(exception)
     case exception
-    when ActiveRecord::RecordNotFound
-      redirect_to root_path, alert: 'Record not found.'
-    when ActionView::MissingTemplate
+    # A URL naming a record that is not there, a template that is not there,
+    # a format nothing can render: one answer for all three.
+    #
+    # RecordNotFound used to redirect to the homepage with a flash instead,
+    # which is kind to someone who mistyped and a lie to everything else -- a
+    # crawler, a stale link and a monitor all saw 302-then-200 for a dead SoC
+    # page. The other two already answered 404.
+    when ActiveRecord::RecordNotFound, ActionView::MissingTemplate,
+         ActionController::UnknownFormat
       render file: Rails.public_path.join('404.html'), layout: false, status: :not_found
-    when ActionController::UnknownFormat
-      render file: Rails.public_path.join('404.html'), layout: false, status: :not_found
-      # render plain: 'Wrong request', status: 404
     when ActionController::InvalidAuthenticityToken
       redirect_to root_path, alert: 'Session expired. Please sign in..'
     else


### PR DESCRIPTION
Follow-up to #70. Making `Soc.find` and `Vendor.find` raise `RecordNotFound` got the 500s off the SoC pages, but verifying on dev showed the ladder turns `RecordNotFound` into a redirect:

```
GET /cameras/vendors/ingenic/socs/t31
-> 302  Location: https://openipc.org/     flash: "Record not found."
```

That is kind to someone who mistyped and a lie to everything else — a crawler, a stale link and a monitor all read `302`-then-`200` as a page that exists.

The two branches immediately below it already rendered `404.html` for the same class of mistake, so the three collapse into one clause:

```ruby
when ActiveRecord::RecordNotFound, ActionView::MissingTemplate,
     ActionController::UnknownFormat
  render file: Rails.public_path.join('404.html'), layout: false, status: :not_found
```

A commented-out `render plain: 'Wrong request', status: 404` went with them.

`InvalidAuthenticityToken` keeps its redirect — an expired session is a state to recover from, not an address that is wrong.

## Verification

`RescueHandler` only installs itself when `Rails.env.production?`, and it registers at class-load time, so it cannot be exercised from the test suite without contortions. dev.openipc.org runs the production image with `RAILS_ENV=production`, which is the honest place to check it, and that is where the 302 was found in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFwmYHCbci2esgc8AMmzJR