### PR TITLE
Refresh db/schema.rb, and pin the collation it had been inheriting

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,6 +12,12 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
+  # Pinned, not inherited. MariaDB's default collation for utf8mb4 changed from
+  # utf8mb4_general_ci to utf8mb4_uca1400_ai_ci in 11.8, so a database built by
+  # db:create + db:migrate would silently differ from production, which is
+  # general_ci throughout. db/schema.rb records it per table for the
+  # schema:load path; this covers the migration path.
+  collation: utf8mb4_general_ci
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 16 } %>
   username: www
   password: www

--- a/config/locales/activerecord.de.yml
+++ b/config/locales/activerecord.de.yml
@@ -13,7 +13,6 @@ de:
         notes: Anmerkungen
         sdk: SDK
         status: Bühne
-        toolchain_filename: Toolchain-Datei
         uboot_filename: U-Boot-Datei
         vendor_id: SoC-Anbieter
         version: Ausführung

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -13,7 +13,6 @@ en:
         notes: Notes
         sdk: SDK
         status: Stage
-        toolchain_filename: Toolchain file
         uboot_filename: U-Boot file
         vendor_id: SoC Vendor
         version: Version

--- a/config/locales/activerecord.es.yml
+++ b/config/locales/activerecord.es.yml
@@ -13,7 +13,6 @@ es:
         notes: Notas
         sdk: SDK
         status: Escenario
-        toolchain_filename: Archivo de cadena de herramientas
         uboot_filename: Archivo de arranque U
         vendor_id: Proveedor de SoC
         version: Versión

--- a/config/locales/activerecord.fa.yml
+++ b/config/locales/activerecord.fa.yml
@@ -13,7 +13,6 @@ fa:
         notes: یادداشت
         sdk: SDK
         status: صحنه
-        toolchain_filename: فایل زنجیره ابزار
         uboot_filename: فایل U-Boot
         vendor_id: فروشنده SoC
         version: نسخه

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -13,7 +13,6 @@ fr:
         notes: Remarques
         sdk: SDK
         status: Scène
-        toolchain_filename: Fichier de chaîne d'outils
         uboot_filename: Fichier U-Boot
         vendor_id: Fournisseur de SoC
         version: Version

--- a/config/locales/activerecord.it.yml
+++ b/config/locales/activerecord.it.yml
@@ -13,7 +13,6 @@ it:
         notes: Appunti
         sdk: SDK
         status: Palcoscenico
-        toolchain_filename: File della catena degli strumenti
         uboot_filename: File U-Boot
         vendor_id: Fornitore del SoC
         version: Versione

--- a/config/locales/activerecord.pl.yml
+++ b/config/locales/activerecord.pl.yml
@@ -13,7 +13,6 @@ pl:
         notes: Notatki
         sdk: SDK
         status: Scena
-        toolchain_filename: Plik łańcucha narzędzi
         uboot_filename: Plik U-Boota
         vendor_id: Dostawca SoC
         version: Wersja

--- a/config/locales/activerecord.pt.yml
+++ b/config/locales/activerecord.pt.yml
@@ -13,7 +13,6 @@ pt:
         notes: Notas
         sdk: SDK
         status: Estágio
-        toolchain_filename: Arquivo de conjunto de ferramentas
         uboot_filename: Arquivo U-Boot
         vendor_id: Fornecedor de SoC
         version: Versão

--- a/config/locales/activerecord.ru.yml
+++ b/config/locales/activerecord.ru.yml
@@ -13,7 +13,6 @@ ru:
         notes: Заметки
         sdk: SDK
         status: Стадия
-        toolchain_filename: Тулчейн
         uboot_filename: Загрузчик
         vendor_id: Производитель SoC
         version: Версия

--- a/config/locales/activerecord.zh.yml
+++ b/config/locales/activerecord.zh.yml
@@ -13,7 +13,6 @@ zh:
         notes: 备注
         sdk: 开发工具包
         status: 阶段
-        toolchain_filename: 工具链文件
         uboot_filename: U-Boot文件
         vendor_id: SoC供应商
         version: 版本

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
-  create_table "active_storage_attachments", charset: "utf8mb4", force: :cascade do |t|
+ActiveRecord::Schema[7.0].define(version: 2023_05_07_193639) do
+  create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", charset: "utf8mb4", force: :cascade do |t|
+  create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,13 +33,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", charset: "utf8mb4", force: :cascade do |t|
+  create_table "active_storage_variant_records", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "admins", charset: "utf8mb4", force: :cascade do |t|
+  create_table "admins", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -65,16 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
     t.index ["unlock_token"], name: "index_admins_on_unlock_token", unique: true
   end
 
-  create_table "custom_commands", charset: "utf8mb4", force: :cascade do |t|
-    t.bigint "soc_id"
-    t.string "command_block"
-    t.text "text"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["soc_id"], name: "index_custom_commands_on_soc_id"
-  end
-
-  create_table "sensors", charset: "utf8mb4", force: :cascade do |t|
+  create_table "sensors", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "urlname"
     t.bigint "vendor_id"
     t.string "model"
@@ -103,7 +94,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
     t.index ["vendor_id"], name: "index_sensors_on_vendor_id"
   end
 
-  create_table "snapshots", charset: "utf8mb4", force: :cascade do |t|
+  create_table "snapshots", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "mac_address"
     t.string "ip_address"
     t.string "hostname"
@@ -115,9 +106,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
     t.string "soc_temperature"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "streamer"
+    t.string "caption"
+    t.index ["created_at"], name: "index_snapshots_on_created_at"
+    t.index ["flash_size"], name: "index_snapshots_on_flash_size"
+    t.index ["ip_address"], name: "index_snapshots_on_ip_address"
+    t.index ["mac_address"], name: "index_snapshots_on_mac_address"
+    t.index ["sensor"], name: "index_snapshots_on_sensor"
+    t.index ["soc"], name: "index_snapshots_on_soc"
   end
 
-  create_table "socs", charset: "utf8mb4", force: :cascade do |t|
+  create_table "socs", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "vendor_id"
     t.string "family"
     t.string "model"
@@ -132,14 +131,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_06_130659) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "urlname"
-    t.string "toolchain_filename"
     t.string "build_status_url"
     t.boolean "featured", default: false, null: false
     t.index ["urlname"], name: "index_socs_on_urlname", unique: true
     t.index ["vendor_id"], name: "index_socs_on_vendor_id"
   end
 
-  create_table "vendors", charset: "utf8mb4", force: :cascade do |t|
+  create_table "vendors", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Follow-up to #68, which had to work around this.

`db/schema.rb` was stamped `2022_08_06_130659` while `db/migrate/` runs to `2023_05_07_193639` — five migrations were never dumped into it. Loading the schema alone produced a 2022 structure and left the suite refusing to start with "Migrations are pending", which the CI job works around by running `db:migrate` afterwards.

Regenerated against a **scratch database, never production**: `schema:load`, `migrate`, `dump`, then dropped. The structural diff is exactly those five migrations:

- `custom_commands` dropped
- `snapshots` gains `streamer`, `caption`, and six indexes
- `socs` loses `toolchain_filename`

## The collation, which is the part worth reading

Every `create_table` specified `charset: "utf8mb4"` with no collation, so tables inherited whatever the server defaults to for that charset. That was `utf8mb4_general_ci` under MariaDB 10.x — which is what production has — but **the default changed to `utf8mb4_uca1400_ai_ci` in 11.8**.

So since yesterday's upgrade, loading this schema produced tables that silently no longer matched production. The first regeneration I did reproduced exactly that:

```
production tables : utf8mb4_general_ci
COLLATION_SERVER  : utf8mb4_uca1400_ai_ci      <- 11.8 default
regenerated dump  : collation: "utf8mb4_uca1400_ai_ci"
```

Recording the collation explicitly removes the dependency on the server default, so the file now means the same thing on any version.

## Verification

Loaded the regenerated file into a scratch database and compared against live production, order-independently:

```
columns (name, type, nullability, default) : identical
indexes (name, column, position, uniqueness): identical
```

A raw `mysqldump` comparison still shows index *ordering* differences — MySQL lists indexes in creation order, and production built them incrementally through migrations. Same indexes, different sequence, no structural difference.

## Not doing here

The CI job keeps `db:migrate` after `db:schema:load`. It is a no-op now, and it is worth keeping as a safety net for the next time the schema drifts.