### PR TITLE
Publish firmware images atomically, and resolve the board from the release name

### DIFF
--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -120,7 +120,16 @@ module Cameras
       @soc = Soc.find(params[:id])
       fw = Firmware.new(size: flash_size, flash_type: flash_type, release: fw_release, soc: @soc)
       fw.generate
-      send_file fw.filepath, name: fw.filename, disposition: :attachment
+      send_file fw.filepath, filename: fw.filename, disposition: :attachment
+    rescue Firmware::PayloadTooLarge => e
+      # The combination is real but does not fit -- Ultimate on 8MB flash is
+      # the one users actually hit. The wizard downgrades it to Lite and says
+      # so, but this action takes flash_size and fw_release from the query
+      # string, so say the same thing here rather than claiming the firmware
+      # does not exist.
+      Rails.logger.warn "full image does not fit for #{params[:id]}: #{e.message}"
+      flash.alert = 'This edition is too large for that flash size. Try the Lite edition, or a larger flash.'
+      redirect_back(fallback_location: '/')
     rescue ActionController::MissingFile, Firmware::MissingMember, Firmware::InvalidFlashSize => e
       # MissingMember means the release tarball does not carry what this flash
       # type needs -- a NAND build with no kernel member, say. Better a missing
@@ -130,6 +139,12 @@ module Cameras
       # can be turned into an allocation.
       Rails.logger.warn "full image unavailable for #{params[:id]}: #{e.message}"
       flash.alert = 'This firmware does not exist.'
+      redirect_back(fallback_location: '/')
+    rescue Firmware::LockTimeout => e
+      # Another request has been building this image for a minute. Saying so is
+      # better than reporting it missing, because retrying will work.
+      Rails.logger.error "full image lock timeout for #{params[:id]}: #{e.message}"
+      flash.alert = 'This firmware is being prepared right now. Please try again in a moment.'
       redirect_back(fallback_location: '/')
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,12 +33,15 @@ module ApplicationHelper
     '^([a-fA-F\d]{2}[:\-]){5}[a-fA-F\d]{2}$'
   end
 
+  # The board rule lives on Soc, which reads it from the name upstream
+  # publishes. This used to carry its own copy -- model.downcase with t31 and
+  # t40 collapsed -- so the tarball this linked to and the one the server
+  # assembled from could disagree: for T23N it offered openipc.t23n-*.tgz,
+  # which 404s, and for AK3916EV301 it offered ak3916ev301 while the server
+  # built from ak3918ev200. It also contradicted the member names in the
+  # SD-card instructions, which come from Soc#kernel_file and Soc#rootfs_file.
   def firmware_filename(camera)
-    soc_name = camera.soc.model.downcase
-    soc_name = 't31' if soc_name.start_with?('t31')
-    soc_name = 't40' if soc_name.start_with?('t40')
-
-    "openipc.#{soc_name}-#{camera.flash_type_type}-#{camera.firmware_version}.tgz"
+    "openipc.#{camera.soc.board}-#{camera.flash_type_type}-#{camera.firmware_version}.tgz"
   end
 
   def firmware_url(camera)

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -13,8 +13,26 @@ class Firmware
   NOR_KERNEL_OFFSET = 0x50000
   NOR_SIZES = [8, 16, 32].freeze
 
+  LOCK_POLL = 0.1
+
+  # Assembly of one image takes about a second. The wait exists only so that
+  # concurrent requests for the same image do not each build it; anything near
+  # this deadline means something is wedged, and failing is better than holding
+  # one of Puma's sixteen threads indefinitely. Settable so the timeout path is
+  # testable without a minute-long test, and tunable on a host without a deploy.
+  class << self
+    attr_accessor :lock_timeout
+  end
+  self.lock_timeout = 60
+
+  # One part of the assembled image: what it is called in an error, its bytes,
+  # where it is written, and the first offset it may not reach.
+  Part = Struct.new(:name, :bytes, :offset, :limit, :limit_name)
+
   class MissingMember < StandardError; end
   class InvalidFlashSize < StandardError; end
+  class PayloadTooLarge < StandardError; end
+  class LockTimeout < StandardError; end
 
   def initialize(size: 8, flash_type: 'nor', release: 'lite', soc: nil)
     super()
@@ -50,46 +68,88 @@ class Firmware
 
     uboot_file = @soc.uboot_file
     unless File.exist?(uboot_file)
-      puts "File #{uboot_file} not found."
+      Rails.logger.warn "firmware: #{uboot_file} not found"
       return
     end
 
     linux_file = @soc.linux_file(@release, @flash_type)
     unless File.exist?(linux_file)
-      puts "File #{linux_file} not found."
+      Rails.logger.warn "firmware: #{linux_file} not found"
       return
     end
 
-    # file exists and it is newer than any of its parts
-    if File.exist?(filepath) &&
-        File.mtime(uboot_file) < File.mtime(filepath) &&
-        File.mtime(linux_file) < File.mtime(filepath)
-      puts "File #{filepath} exists and is fresh."
-      return
-    end
+    return if fresh?(uboot_file, linux_file)
 
+    FileUtils.mkdir_p File.dirname(filepath)
+    with_lock do
+      # Whoever held the lock may have been building this very image, so ask
+      # again now rather than assembling a second identical copy.
+      return if fresh?(uboot_file, linux_file)
+
+      assemble(uboot_file, linux_file)
+    end
+  end
+
+  private
+
+  # file exists and it is newer than any of its parts
+  def fresh?(uboot_file, linux_file)
+    File.exist?(filepath) &&
+      File.mtime(uboot_file) < File.mtime(filepath) &&
+      File.mtime(linux_file) < File.mtime(filepath)
+  end
+
+  # The build itself. Everything here happens on a temporary file; `filepath`
+  # is only ever created by the rename at the end.
+  def assemble(uboot_file, linux_file)
     data, present = read_members(linux_file, [kernel_member, rootfs_member])
     kernel = fetch_member!(data, kernel_member, linux_file, present)
     rootfs = fetch_member!(data, rootfs_member, linux_file, present)
 
     # Resolve every offset and the length before allocating anything, so an
     # unsupported size cannot get as far as filling a buffer with it.
-    k_offset = kernel_offset
-    r_offset = rootfs_offset
     size = image_size(rootfs)
+    parts = layout(IO.binread(uboot_file), kernel, rootfs, size)
+    validate_fit!(parts)
 
-    # create directory
-    FileUtils.mkdir_p File.dirname(filepath)
-
-    tmp_file = Tempfile.create
-    IO.binwrite tmp_file, ("\xFF" * size)
-    IO.binwrite tmp_file, IO.binread(uboot_file), 0
-    IO.binwrite tmp_file, kernel, k_offset
-    IO.binwrite tmp_file, rootfs, r_offset
-    FileUtils.mv tmp_file, filepath
+    publish(size, parts)
   end
 
-  private
+  # Where each part goes, and the first offset it may not reach. Written in
+  # this order so a part can only ever be overwritten by one that follows it.
+  def layout(uboot, kernel, rootfs, size)
+    [
+      Part.new('u-boot', uboot, 0, kernel_offset, 'the kernel offset'),
+      Part.new('kernel', kernel, kernel_offset, rootfs_offset, 'the rootfs offset'),
+      Part.new('rootfs', rootfs, rootfs_offset, size, 'the end of the image')
+    ]
+  end
+
+  # Build beside the destination and rename into place.
+  #
+  # This used to build in Dir.tmpdir and hand the result to FileUtils.mv. In
+  # the container /tmp is the overlay and public/files is a bind mount from the
+  # host, so File.rename raised EXDEV and mv fell back to copy-then-unlink --
+  # writing 8-32MB straight into the live filename. Since `fresh?` is satisfied
+  # by a file that merely exists and has a recent mtime, a request arriving
+  # during that copy was served a partial image, and an interrupted copy left
+  # one on disk to be served indefinitely. Nothing publishes a checksum for the
+  # assembled .bin, so neither we nor the user could detect it.
+  #
+  # A rename within one directory is atomic, so filepath only ever names a
+  # complete image.
+  def publish(size, parts)
+    tmp = Tempfile.create([tmp_prefix, '.bin'], File.dirname(filepath))
+    begin
+      tmp.close
+      IO.binwrite tmp.path, ("\xFF" * size)
+      parts.each { |part| IO.binwrite tmp.path, part.bytes, part.offset }
+      File.rename(tmp.path, filepath)
+    rescue StandardError
+      FileUtils.rm_f(tmp.path)
+      raise
+    end
+  end
 
   # size is a request parameter, so it has to be checked before it can be turned
   # into an allocation. Guarding here rather than relying on rootfs_offset to
@@ -100,6 +160,58 @@ class Firmware
     return if NOR_SIZES.include?(@size)
 
     raise InvalidFlashSize, "unsupported NOR flash size #{@size}MB (expected #{NOR_SIZES.join(', ')})"
+  end
+
+  # IO.binwrite past the end of a file grows it rather than failing, so a part
+  # too big for its slot produced an image larger than the chip it names
+  # instead of an error. openipc-hi3516ev200-nor-ultimate-8mb.bin was found on
+  # disk at 9,465,856 bytes: 0x250000 for the rootfs offset plus a 7MB Ultimate
+  # rootfs, in a file whose name promises 8MB. The installation wizard refuses
+  # Ultimate on 8MB flash, but download_full_image takes flash_size and
+  # fw_release straight from the query string and had no equivalent check.
+  #
+  # Checked against the parts themselves rather than by re-deriving the rule,
+  # so this also covers a build that simply outgrows its partition.
+  def validate_fit!(parts)
+    parts.each do |part|
+      bytes = part.bytes.bytesize
+      overrun = part.offset + bytes - part.limit
+      next if overrun <= 0
+
+      raise PayloadTooLarge,
+            "#{part.name} is #{bytes} bytes at 0x#{part.offset.to_s(16)}, which runs #{overrun} bytes " \
+            "past #{part.limit_name} (0x#{part.limit.to_s(16)}) of #{filename}"
+    end
+  end
+
+  # Serialises assembly of one image across requests and processes. The lock
+  # file is separate from the image so the rename cannot invalidate it, and
+  # acquisition is a non-blocking poll against a deadline because flock offers
+  # no timeout and a blocked thread here is a thread the whole site loses.
+  def with_lock
+    lock = File.open(lock_path, File::CREAT | File::RDWR, 0o644)
+    timeout = self.class.lock_timeout
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until lock.flock(File::LOCK_EX | File::LOCK_NB)
+      raise LockTimeout, "waited #{timeout}s for another request to finish building #{filename}" \
+        if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
+
+      sleep LOCK_POLL
+    end
+    yield
+  ensure
+    lock&.flock(File::LOCK_UN)
+    lock&.close
+  end
+
+  def lock_path
+    File.join(File.dirname(filepath), ".#{filename}.lock")
+  end
+
+  # Dot-prefixed so nginx's autoindex on /files/ does not list a half-built
+  # image, and named for the target so a leftover says which build died.
+  def tmp_prefix
+    ".tmp-#{filename}-"
   end
 
   # One pass, reading only the two bodies we need -- rootfs.ubi runs to 16MB and
@@ -139,24 +251,20 @@ class Firmware
     raise MissingMember, "#{name} is not in #{File.basename(linux_file)} (members: #{listed})"
   end
 
-  def soc_model
-    @soc_model ||= @soc.model_downcase
+  # Members are named for the board the firmware was built for, which is not
+  # always the SoC model -- see Soc#board.
+  def board
+    @board ||= @soc.board
   end
 
   def kernel_member
-    # Ingenic ships one kernel for the whole family rather than one per model.
-    return 'uImage.t31' if soc_model.starts_with?('t31')
-    return 'uImage.t40' if soc_model.starts_with?('t40')
-
-    "uImage.#{soc_model}"
+    "uImage.#{board}"
   end
 
   def rootfs_member
-    return "rootfs.ubi.#{soc_model}" if nand?
-    return 'rootfs.squashfs.t31' if soc_model.starts_with?('t31')
-    return 'rootfs.squashfs.t40' if soc_model.starts_with?('t40')
+    return "rootfs.ubi.#{board}" if nand?
 
-    "rootfs.squashfs.#{soc_model}"
+    "rootfs.squashfs.#{board}"
   end
 
   def kernel_offset

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -139,16 +139,34 @@ class Firmware
   # A rename within one directory is atomic, so filepath only ever names a
   # complete image.
   def publish(size, parts)
+    purge_stale_builds
     tmp = Tempfile.create([tmp_prefix, '.bin'], File.dirname(filepath))
-    begin
-      tmp.close
-      IO.binwrite tmp.path, ("\xFF" * size)
-      parts.each { |part| IO.binwrite tmp.path, part.bytes, part.offset }
-      File.rename(tmp.path, filepath)
-    rescue StandardError
-      FileUtils.rm_f(tmp.path)
-      raise
-    end
+    tmp.close
+    IO.binwrite tmp.path, ("\xFF" * size)
+    parts.each { |part| IO.binwrite tmp.path, part.bytes, part.offset }
+    File.rename(tmp.path, filepath)
+  ensure
+    # `ensure` rather than `rescue StandardError`, so an Interrupt or a
+    # SignalException clears up after itself too. After the rename the path is
+    # gone, so this is a no-op on the happy path.
+    FileUtils.rm_f(tmp.path) if tmp && File.exist?(tmp.path)
+  end
+
+  # Debris used to land in Dir.tmpdir, which the container discards on restart.
+  # It now lands beside the image, in a directory nginx serves and nothing
+  # prunes, so a build killed outrightly -- SIGKILL, OOM, a container stopped
+  # mid-write -- would leave a partial image there for good.
+  #
+  # Running under the lock is what makes this safe: no other process is
+  # building this image, so any temporary file bearing its prefix is from a
+  # build that is already over. Each image clears its own debris on its next
+  # build, which bounds the leftovers at one per image never built again.
+  def purge_stale_builds
+    stale = Dir.glob(File.join(File.dirname(filepath), "#{tmp_prefix}*"))
+    return if stale.empty?
+
+    Rails.logger.warn "firmware: clearing #{stale.size} abandoned build(s) of #{filename}"
+    FileUtils.rm_f(stale)
   end
 
   # size is a request parameter, so it has to be checked before it can be turned

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -92,11 +92,29 @@ class Firmware
 
   private
 
-  # file exists and it is newer than any of its parts
+  # file exists, is the size it claims to be, and is newer than any of its parts
   def fresh?(uboot_file, linux_file)
     File.exist?(filepath) &&
+      right_size? &&
       File.mtime(uboot_file) < File.mtime(filepath) &&
       File.mtime(linux_file) < File.mtime(filepath)
+  end
+
+  # A NOR image is exactly its flash size by construction, so anything else is
+  # a leftover from before that was enforced: the 9,465,856-byte
+  # openipc-hi3516ev200-nor-ultimate-8mb.bin, or a partial image from the
+  # cross-filesystem copy this class used to publish with. public/files is a
+  # host mount that outlives deploys and nothing prunes it, so checking only
+  # mtimes would go on serving those until their source tarball happened to
+  # change. NAND is sized from its payload and has no equivalent invariant.
+  def right_size?
+    return true if nand?
+
+    actual = File.size(filepath)
+    return true if actual == @size.megabytes
+
+    Rails.logger.warn "firmware: rebuilding #{filename}, cached copy is #{actual} bytes, expected #{@size.megabytes}"
+    false
   end
 
   # The build itself. Everything here happens on a temporary file; `filepath`
@@ -154,7 +172,7 @@ class Firmware
 
   # Debris used to land in Dir.tmpdir, which the container discards on restart.
   # It now lands beside the image, in a directory nginx serves and nothing
-  # prunes, so a build killed outrightly -- SIGKILL, OOM, a container stopped
+  # prunes, so a build killed outright -- SIGKILL, OOM, a container stopped
   # mid-write -- would leave a partial image there for good.
   #
   # Running under the lock is what makes this safe: no other process is

--- a/app/models/soc.rb
+++ b/app/models/soc.rb
@@ -88,8 +88,21 @@ class Soc < ApplicationRecord
   # fortnight, the largest single cause. T30L was the same bug.
   BOARD_FROM_FILENAME = /\Aopenipc\.(.+)-(?:nor|nand)-[a-z0-9]+\.tgz\z/
 
+  # Families that ship one build for every model in them. Only consulted when
+  # linux_filename cannot answer; it covers more cases than this list can.
+  FAMILY_BUILDS = %w[t31 t40 t30 t23].freeze
+
   def board
-    @board ||= linux_filename.to_s[BOARD_FROM_FILENAME, 1] || model_downcase
+    @board ||= linux_filename.to_s[BOARD_FROM_FILENAME, 1] || family_board
+  end
+
+  # Reached when linux_filename is blank or still in the pre-2023
+  # openipc.<soc>-br.tgz scheme, which is what db/seeds.rb carries for all 48
+  # of its entries. Production rows are all on the current scheme, but a fresh
+  # install has no modern name to read, so dropping this rule would have T31X
+  # ask for a t31x build that upstream has never published.
+  def family_board
+    FAMILY_BUILDS.find { |family| model_downcase.start_with?(family) } || model_downcase
   end
 
   # Not memoised: it takes arguments, and `@linux_file ||=` returned the first

--- a/app/models/soc.rb
+++ b/app/models/soc.rb
@@ -72,20 +72,34 @@ class Soc < ApplicationRecord
   end
 
   def kernel_file
-    @kernel_file ||= "uImage.#{model_downcase}"
+    @kernel_file ||= "uImage.#{board}"
   end
 
-  def linux_file(release, flash_type)
-    soc_name = model.downcase
-    soc_name = 't31' if soc_name.start_with?('t31')
-    soc_name = 't40' if soc_name.start_with?('t40')
-    linux_filename = "openipc.#{soc_name}-#{flash_type}-#{release}.tgz"
+  # The board a firmware is built for, which is not always the SoC model.
+  # Ingenic ships one build per family (T31X, T31N and the rest all flash
+  # openipc.t31-*), Goke does the same across the GK7102 variants, and
+  # AK3916EV301 runs the AK3918EV200 build outright. None of that is derivable
+  # from the model string, so it is read out of linux_filename, which carries
+  # the name upstream actually publishes.
+  #
+  # This used to be guessed as model.downcase with hardcoded exceptions for
+  # t31 and t40 only. T23N therefore asked for openipc.t23n-nor-lite.tgz, a
+  # file that has never existed -- 31 of the 99 failed firmware downloads in a
+  # fortnight, the largest single cause. T30L was the same bug.
+  BOARD_FROM_FILENAME = /\Aopenipc\.(.+)-(?:nor|nand)-[a-z0-9]+\.tgz\z/
 
-    @linux_file ||= File.join(RELEASES_ROOT, linux_filename)
+  def board
+    @board ||= linux_filename.to_s[BOARD_FROM_FILENAME, 1] || model_downcase
+  end
+
+  # Not memoised: it takes arguments, and `@linux_file ||=` returned the first
+  # call's path for every later one regardless of what was asked for.
+  def linux_file(release, flash_type)
+    File.join(RELEASES_ROOT, "openipc.#{board}-#{flash_type}-#{release}.tgz")
   end
 
   def rootfs_file
-    @rootfs_file ||= "rootfs.squashfs.#{model_downcase}"
+    @rootfs_file ||= "rootfs.squashfs.#{board}"
   end
 
   def uboot_file

--- a/app/views/admin/socs/show.html.erb
+++ b/app/views/admin/socs/show.html.erb
@@ -84,10 +84,10 @@
   <h4>Download full-size binaries</h4>
   <p>
     <% %w[mini lite].each do |release| %>
-      <%= link_to "8MB #{release}", download_full_image_cameras_vendor_soc_path(@soc.vendor, @soc, fw_release: release, flash_size: 8), class: "btn btn-primary" %>
+      <%= link_to "8MB #{release}", download_full_image_cameras_vendor_soc_path(@soc.vendor, @soc, fw_release: release, flash_size: 8, flash_type: 'nor'), class: "btn btn-primary" %>
     <% end %>
     <% %w[ultimate fpv].each do |release| %>
-      <%= link_to "16MB #{release}", download_full_image_cameras_vendor_soc_path(@soc.vendor, @soc, fw_release: release, flash_size: 16), class: "btn btn-primary" %>
+      <%= link_to "16MB #{release}", download_full_image_cameras_vendor_soc_path(@soc.vendor, @soc, fw_release: release, flash_size: 16, flash_type: 'nor'), class: "btn btn-primary" %>
     <% end %>
   </p>
 

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -313,6 +313,38 @@ class FirmwareTest < ActiveSupport::TestCase
     assert_equal 8.megabytes, File.size(fw.filepath)
   end
 
+  test 'an abandoned build is cleared by the next build of the same image' do
+    # A SIGKILL or an OOM leaves the temporary file behind: no rescue and no
+    # ensure runs. Debris used to land in Dir.tmpdir, which the container
+    # discards on restart; it now lands in the directory nginx serves and
+    # nothing prunes, so the next build has to clear it.
+    fw = build(model: 'hi3516cv500', vendor: 'HiSilicon', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.hi3516cv500' => KERNEL, 'rootfs.squashfs.hi3516cv500' => SQUASHFS })
+    FileUtils.mkdir_p File.dirname(fw.filepath)
+    abandoned = File.join(File.dirname(fw.filepath), ".tmp-#{fw.filename}-orphan.bin")
+    IO.binwrite(abandoned, 'partial')
+
+    fw.generate
+
+    assert_not File.exist?(abandoned), 'an abandoned build was left in the served directory'
+    assert_empty leftover_temp_files(fw)
+    assert_equal 8.megabytes, File.size(fw.filepath)
+  end
+
+  test 'a build interrupted by a signal does not leave a partial image behind' do
+    fw = build(model: 'ssc335', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.ssc335' => KERNEL, 'rootfs.squashfs.ssc335' => SQUASHFS })
+
+    # Interrupt is not a StandardError, so `rescue StandardError` would have
+    # let it through with the temporary file still on disk.
+    File.stub(:rename, ->(*) { raise Interrupt }) do
+      assert_raises(Interrupt) { fw.generate }
+    end
+
+    assert_not File.exist?(fw.filepath)
+    assert_empty leftover_temp_files(fw), 'the interrupted build was left behind'
+  end
+
   test 'a second generate reuses the cached image instead of rebuilding it' do
     fw = build(model: 'ssc337', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
                members: { 'uImage.ssc337' => KERNEL, 'rootfs.squashfs.ssc337' => SQUASHFS })

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -5,15 +5,20 @@ require 'rubygems/package'
 require 'zlib'
 require 'tmpdir'
 require 'benchmark'
+require 'minitest/mock'
 
 class FirmwareTest < ActiveSupport::TestCase
   StubVendor = Struct.new(:name)
 
   class StubSoc
-    attr_reader :model_downcase, :vendor, :uboot_file
+    attr_reader :model_downcase, :vendor, :uboot_file, :board
 
-    def initialize(model:, vendor:, uboot_file:, linux_file:)
+    # board defaults to the model because for most SoCs they are the same. The
+    # ones where they are not -- T23N on the t23 build, the GK7102 variants,
+    # AK3916EV301 on the AK3918EV200 build -- are what Soc#board exists for.
+    def initialize(model:, vendor:, uboot_file:, linux_file:, board: nil)
       @model_downcase = model
+      @board = board || model
       @vendor = StubVendor.new(vendor)
       @uboot_file = uboot_file
       @linux_file = linux_file
@@ -55,13 +60,20 @@ class FirmwareTest < ActiveSupport::TestCase
     @uboot_path ||= File.join(@dir, 'u-boot.bin').tap { |p| IO.binwrite(p, UBOOT) }
   end
 
-  def build(model:, vendor:, members:, flash_type:, size:, release: 'ultimate')
-    soc = StubSoc.new(model: model, vendor: vendor, uboot_file: uboot_path,
-                      linux_file: write_tgz("openipc.#{model}-#{flash_type}-#{release}.tgz", members))
+  def build(model:, vendor:, members:, flash_type:, size:, release: 'ultimate', board: nil)
+    soc = StubSoc.new(model: model, vendor: vendor, board: board, uboot_file: uboot_path,
+                      linux_file: write_tgz("openipc.#{board || model}-#{flash_type}-#{release}.tgz", members))
     fw = Firmware.new(size: size, flash_type: flash_type, release: release, soc: soc)
     @generated << fw.filepath
+    @generated << File.join(File.dirname(fw.filepath), ".#{fw.filename}.lock")
     FileUtils.rm_f(fw.filepath)
     fw
+  end
+
+  # Half-built images are named for their target, so a leftover is attributable
+  # to one build rather than to the suite as a whole.
+  def leftover_temp_files(firmware)
+    Dir.glob(File.join(File.dirname(firmware.filepath), ".tmp-#{firmware.filename}-*"))
   end
 
   # --- filename ---
@@ -207,5 +219,145 @@ class FirmwareTest < ActiveSupport::TestCase
     fw.generate
 
     assert_equal KERNEL, IO.binread(fw.filepath)[0x100000, KERNEL.bytesize]
+  end
+
+  # --- the board is not always the model ---
+
+  test 'members are named for the board rather than the model' do
+    # T23N flashes the t23 build: the tarball holds uImage.t23 and
+    # rootfs.squashfs.t23. Asking for uImage.t23n found nothing, which is where
+    # 31 of the 99 failed downloads in a fortnight came from.
+    fw = build(model: 't23n', board: 't23', vendor: 'Ingenic', flash_type: 'nor', size: 8,
+               release: 'lite',
+               members: { 'uImage.t23' => KERNEL, 'rootfs.squashfs.t23' => SQUASHFS })
+    fw.generate
+
+    assert_equal 8.megabytes, File.size(fw.filepath)
+    assert_equal KERNEL, IO.binread(fw.filepath)[0x50000, KERNEL.bytesize]
+    assert_equal 'openipc-t23n-nor-lite-8mb.bin', fw.filename,
+                 'the download is still named for the SoC the user chose'
+  end
+
+  test 'a nand board build takes rootfs.ubi named for the board' do
+    fw = build(model: 't31x', board: 't31', vendor: 'Ingenic', flash_type: 'nand', size: 128,
+               members: { 'uImage.t31' => KERNEL, 'rootfs.ubi.t31' => UBI })
+    fw.generate
+
+    assert_equal UBI, IO.binread(fw.filepath)[0x400000, UBI.bytesize]
+  end
+
+  # --- a part too big for its slot ---
+
+  test 'a rootfs too large for the flash is refused rather than written past the end' do
+    # openipc-hi3516ev200-nor-ultimate-8mb.bin was found in the production
+    # cache at 9,465,856 bytes -- 0x250000 plus a 7MB Ultimate rootfs, in a
+    # file whose name promises 8MB. IO.binwrite past the end grows the file
+    # instead of failing, so nothing objected.
+    oversize = "\xC3".b * (8.megabytes - 0x250000 + 1)
+    fw = build(model: 'hi3516ev200', vendor: 'HiSilicon', flash_type: 'nor', size: 8,
+               members: { 'uImage.hi3516ev200' => KERNEL, 'rootfs.squashfs.hi3516ev200' => oversize })
+
+    error = assert_raises(Firmware::PayloadTooLarge) { fw.generate }
+    assert_match(/rootfs/, error.message)
+    assert_not File.exist?(fw.filepath), 'an image larger than its flash must not be left to be served'
+  end
+
+  test 'a rootfs that exactly fills the flash is still built' do
+    exact = "\xC3".b * (8.megabytes - 0x250000)
+    fw = build(model: 'hi3516ev200', vendor: 'HiSilicon', flash_type: 'nor', size: 8,
+               members: { 'uImage.hi3516ev200' => KERNEL, 'rootfs.squashfs.hi3516ev200' => exact })
+    fw.generate
+
+    assert_equal 8.megabytes, File.size(fw.filepath)
+  end
+
+  test 'a kernel that would run into the rootfs is refused' do
+    oversize = "\xA5".b * (0x250000 - 0x50000 + 1)
+    fw = build(model: 'hi3516ev200', vendor: 'HiSilicon', flash_type: 'nor', size: 8,
+               members: { 'uImage.hi3516ev200' => oversize, 'rootfs.squashfs.hi3516ev200' => SQUASHFS })
+
+    error = assert_raises(Firmware::PayloadTooLarge) { fw.generate }
+    assert_match(/kernel/, error.message)
+    assert_not File.exist?(fw.filepath)
+  end
+
+  # --- publishing ---
+
+  test 'a failed build leaves neither an image nor a temporary file behind' do
+    oversize = "\xC3".b * (8.megabytes - 0x250000 + 1)
+    fw = build(model: 'hi3516cv300', vendor: 'HiSilicon', flash_type: 'nor', size: 8,
+               members: { 'uImage.hi3516cv300' => KERNEL, 'rootfs.squashfs.hi3516cv300' => oversize })
+
+    assert_raises(Firmware::PayloadTooLarge) { fw.generate }
+    assert_not File.exist?(fw.filepath)
+    assert_empty leftover_temp_files(fw), 'a half-built image was left in the served directory'
+  end
+
+  test 'the image is built beside its destination so publishing is a rename' do
+    # In the container Dir.tmpdir is the overlay and public/files is a bind
+    # mount, so building in Dir.tmpdir made FileUtils.mv fall back to
+    # copy-then-unlink -- writing megabytes into the live filename, where a
+    # concurrent request could be served the partial result.
+    fw = build(model: 'hi3518ev300', vendor: 'HiSilicon', flash_type: 'nor', size: 8,
+               members: { 'uImage.hi3518ev300' => KERNEL, 'rootfs.squashfs.hi3518ev300' => SQUASHFS })
+
+    seen = []
+    original = Tempfile.method(:create)
+    Tempfile.stub(:create, lambda { |basename, dir = nil|
+      seen << dir
+      original.call(basename, dir || Dir.tmpdir)
+    }) { fw.generate }
+
+    assert_equal [File.dirname(fw.filepath)], seen,
+                 'the temporary file must share a filesystem with the destination'
+    assert_equal 8.megabytes, File.size(fw.filepath)
+  end
+
+  test 'a second generate reuses the cached image instead of rebuilding it' do
+    fw = build(model: 'ssc337', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.ssc337' => KERNEL, 'rootfs.squashfs.ssc337' => SQUASHFS })
+    fw.generate
+    first = File.mtime(fw.filepath)
+
+    fw.generate
+    assert_equal first, File.mtime(fw.filepath), 'a fresh image was rebuilt anyway'
+  end
+
+  # --- concurrency ---
+
+  test 'concurrent requests for one image produce a single complete file' do
+    members = { 'uImage.gk7205v300' => KERNEL, 'rootfs.squashfs.gk7205v300' => SQUASHFS }
+    builders = Array.new(4) do
+      build(model: 'gk7205v300', vendor: 'Goke', flash_type: 'nor', size: 16, release: 'lite',
+            members: members)
+    end
+    FileUtils.rm_f(builders.first.filepath)
+
+    builders.map { |fw| Thread.new { fw.generate } }.each(&:join)
+
+    path = builders.first.filepath
+    assert_equal 16.megabytes, File.size(path), 'the published image is not a whole image'
+    assert_equal KERNEL, IO.binread(path)[0x50000, KERNEL.bytesize]
+    assert_equal SQUASHFS, IO.binread(path)[0x350000, SQUASHFS.bytesize]
+    assert_empty leftover_temp_files(builders.first)
+  end
+
+  test 'a build waiting on a stuck holder gives up rather than holding the thread' do
+    fw = build(model: 'ssc325', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.ssc325' => KERNEL, 'rootfs.squashfs.ssc325' => SQUASHFS })
+    lock_path = File.join(File.dirname(fw.filepath), ".#{fw.filename}.lock")
+    FileUtils.mkdir_p(File.dirname(lock_path))
+
+    holder = File.open(lock_path, File::CREAT | File::RDWR, 0o644)
+    holder.flock(File::LOCK_EX)
+    previous = Firmware.lock_timeout
+    Firmware.lock_timeout = 0.3
+    begin
+      assert_raises(Firmware::LockTimeout) { fw.generate }
+    ensure
+      Firmware.lock_timeout = previous
+      holder.flock(File::LOCK_UN)
+      holder.close
+    end
   end
 end

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -345,6 +345,23 @@ class FirmwareTest < ActiveSupport::TestCase
     assert_empty leftover_temp_files(fw), 'the interrupted build was left behind'
   end
 
+  test 'a cached image that is not its declared size is rebuilt, not served' do
+    # openipc-hi3516ev200-nor-ultimate-8mb.bin sat in the production cache at
+    # 9,465,856 bytes. public/files is a host mount that outlives deploys and
+    # nothing prunes it, so a check on mtimes alone would have gone on serving
+    # it until its source tarball happened to change.
+    fw = build(model: 'hi3516dv100', vendor: 'HiSilicon', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.hi3516dv100' => KERNEL, 'rootfs.squashfs.hi3516dv100' => SQUASHFS })
+    FileUtils.mkdir_p File.dirname(fw.filepath)
+    IO.binwrite(fw.filepath, "\x00".b * (8.megabytes + 1024))
+    FileUtils.touch(fw.filepath)
+
+    fw.generate
+
+    assert_equal 8.megabytes, File.size(fw.filepath), 'the oversized cache entry was served instead of rebuilt'
+    assert_equal SQUASHFS, IO.binread(fw.filepath)[0x250000, SQUASHFS.bytesize]
+  end
+
   test 'a second generate reuses the cached image instead of rebuilding it' do
     fw = build(model: 'ssc337', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
                members: { 'uImage.ssc337' => KERNEL, 'rootfs.squashfs.ssc337' => SQUASHFS })

--- a/test/models/soc_test.rb
+++ b/test/models/soc_test.rb
@@ -38,4 +38,59 @@ class SocTest < ActiveSupport::TestCase
     assert_nil Soc.find_by_param(nil)
     assert_nil Soc.find_by_param('')
   end
+
+  # --- which build a SoC actually flashes ---
+
+  test 'board falls back to the model when nothing says otherwise' do
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516CV500',
+                      linux_filename: 'openipc.ts3516cv500-nor-lite.tgz')
+    assert_equal 'ts3516cv500', soc.board
+  end
+
+  test 'board follows linux_filename where the build is shared across a family' do
+    # Ingenic ships one build per family: T23N, like T31X and the rest, flashes
+    # a tarball named for the family, and its members are named to match. The
+    # board used to be guessed from the model with exceptions hardcoded for
+    # t31 and t40 only, so T23N asked for openipc.t23n-nor-lite.tgz -- a file
+    # that has never been published.
+    soc = Soc.create!(vendor: @vendor, model: 'T23N',
+                      linux_filename: 'openipc.t23-nor-lite.tgz')
+    assert_equal 't23', soc.board
+    assert_equal '/srv/github-releases/openipc.t23-nor-lite.tgz',
+                 soc.linux_file('lite', 'nor')
+  end
+
+  test 'board handles a build named for something other than the family' do
+    # AK3916EV301 runs the AK3918EV200 build outright, which no rule derived
+    # from the model string could ever produce.
+    soc = Soc.create!(vendor: @vendor, model: 'AK3916EV301',
+                      linux_filename: 'openipc.ak3918ev200-nor-lite.tgz')
+    assert_equal 'ak3918ev200', soc.board
+  end
+
+  test 'board copes with a hyphenated board name' do
+    soc = Soc.create!(vendor: @vendor, model: 'S3L',
+                      linux_filename: 'openipc.ambarella-s3l-nor-lite.tgz')
+    assert_equal 'ambarella-s3l', soc.board
+  end
+
+  test 'board ignores a filename that is not in the published scheme' do
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516EV200',
+                      linux_filename: 'openipc.ts3516ev200-br.tgz')
+    assert_equal 'ts3516ev200', soc.board, 'a legacy name must not be parsed for a board'
+  end
+
+  test 'linux_file answers each release and flash type it is asked for' do
+    # `@linux_file ||=` returned the first call's path for every later one, so
+    # asking one Soc for two variants handed back the same tarball twice.
+    soc = Soc.create!(vendor: @vendor, model: 'TS3519DV500',
+                      linux_filename: 'openipc.ts3519dv500-nor-lite.tgz')
+
+    assert_equal '/srv/github-releases/openipc.ts3519dv500-nor-lite.tgz',
+                 soc.linux_file('lite', 'nor')
+    assert_equal '/srv/github-releases/openipc.ts3519dv500-nor-ultimate.tgz',
+                 soc.linux_file('ultimate', 'nor')
+    assert_equal '/srv/github-releases/openipc.ts3519dv500-nand-ultimate.tgz',
+                 soc.linux_file('ultimate', 'nand')
+  end
 end

--- a/test/models/soc_test.rb
+++ b/test/models/soc_test.rb
@@ -80,6 +80,23 @@ class SocTest < ActiveSupport::TestCase
     assert_equal 'ts3516ev200', soc.board, 'a legacy name must not be parsed for a board'
   end
 
+  test 'the family rule still answers for a legacy filename' do
+    # db/seeds.rb carries the pre-2023 openipc.<soc>-br.tgz name for all 48 of
+    # its entries, so a fresh install has nothing modern to read. Without the
+    # fallback T31X would ask for a t31x build, which upstream has never
+    # published -- the very regression this change exists to fix.
+    %w[T31X T40XP T30L T23N].each do |model|
+      soc = Soc.create!(vendor: @vendor, model: model,
+                        linux_filename: "openipc.#{model.downcase}-br.tgz")
+      assert_equal model.downcase[0, 3], soc.board, "#{model} lost its family build"
+    end
+  end
+
+  test 'the family rule leaves an unrelated model alone' do
+    soc = Soc.create!(vendor: @vendor, model: 'TS3518EV300', linux_filename: '')
+    assert_equal 'ts3518ev300', soc.board
+  end
+
   test 'linux_file answers each release and flash type it is asked for' do
     # `@linux_file ||=` returned the first call's path for every later one, so
     # asking one Soc for two variants handed back the same tarball twice.


### PR DESCRIPTION
Stage 1 of replacing the eager GitHub release mirror with a lazy cache. These
three defects were found while measuring the mirror, all sit on the firmware
assembly path, and all are independent of the caching work — so they ship first.

## 1. Images were published non-atomically

`Firmware#generate` built into `Tempfile.create` (→ `Dir.tmpdir`) and published
with `FileUtils.mv`. Verified in the production container:

```
/tmp                 dev=44    (overlay)
/rails/public/files  dev=2049  (host bind mount)
File.rename → Errno::EXDEV
```

So `mv` fell back to copy-then-unlink, writing 8–32 MB **into the live
destination filename**. The freshness guard is `File.exist? && mtime(inputs) <
mtime(filepath)`, which a half-copied destination satisfies — it exists, and its
mtime is now. A concurrent request was served a partial firmware image; an
interrupted copy left one on disk to be served indefinitely. No checksum is
published for the assembled `.bin`, so neither we nor the user could detect it.

Now built beside its destination and renamed into place, under a per-filename
`flock` that re-checks freshness after acquiring, so sixteen concurrent cold
requests for a 32 MB image assemble once instead of sixteen times.

## 2. An 8 MB image that was 9.4 MB

Found live in the production cache:

```
openipc-hi3516ev200-nor-ultimate-8mb.bin   9,465,856 bytes
```

`image_size` fills `@size.megabytes` = 8,388,608, then `IO.binwrite(tmp, rootfs,
0x250000)` writes past the end and grows the file — 2,437,120 + 7,028,736 =
9,465,856 exactly. Nothing checked that a part fitted its slot. The wizard
refuses Ultimate on 8 MB flash (`socs_controller.rb:103-105`), but
`download_full_image` reads `flash_size` and `fw_release` straight from the
query string and had no equivalent guard.

Each part is now checked against the first offset it may not reach, and the
controller answers "this edition is too large for that flash size" rather than
"this firmware does not exist".

## 3. The board was guessed instead of resolved

`Soc#linux_file` composed `openipc.<model>-…` with family collapses hardcoded
for `t31`/`t40` only, ignoring the `linux_filename` column that already holds
the name upstream publishes. **T23N** asked for `openipc.t23n-nor-lite.tgz` — a
file that has never existed. That is **31 of the 99 failed firmware downloads in
15 days of access logs, the largest single cause**, with T30L behind it.

Reading the board out of `linux_filename` also covers cases no rule could
derive: the GK7102 variants, and AK3916EV301 which runs the AK3918EV200 build
outright. The argument-ignoring `@linux_file ||=` memo goes with it — it
returned the first call's path for every later one, which would have corrupted
any pre-generation warm job.

## Testing

`bin/rails test` — 53 runs, 130 assertions, 0 failures, green three times under
24 parallel workers. Run in a CI-equivalent container (ruby 3.1.7 + mariadb
11.8). New coverage: board-vs-model resolution, oversize rootfs and kernel
refused with nothing left behind, exact-fit still builds, the temp file shares a
filesystem with its destination, concurrent generation yields one complete file,
and a stuck lock holder produces `LockTimeout` rather than a held thread.

`rubocop` 38 offences vs 37 on master, with `generate` down from 30 lines to 17
and two `Layout` offences removed; the delta is `Style/HashSyntax` shorthand
suggestions that match the surrounding code.

## After merge

`openipc-hi3516ev200-nor-ultimate-8mb.bin` should be deleted from
`/srv/www/shared/files` **after** this deploys — until then it would just be
regenerated oversized on the next request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn