### PR TITLE
Mirror only what the site reads, and take away what it does not

### DIFF
--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -168,13 +168,18 @@ def newest_assets
       name = asset['name']
       next if chosen.key?(name) || skipped.key?(name)
 
-      unless consumed?(name)
-        skipped[name] = family_of(name)
+      # Before anything is decided about a name, and before any of it reaches a
+      # log line. The skip path below reports the family it belongs to, and an
+      # asset that never passed this check could put a newline in that line and
+      # forge cron log entries -- which is the exact thing plain_filename?
+      # exists to prevent, so it has to come first.
+      unless plain_filename?(name)
+        log "  refusing #{name.inspect} from #{release.tag_name}: not a plain filename"
         next
       end
 
-      unless plain_filename?(name)
-        log "  refusing #{name.inspect} from #{release.tag_name}: not a plain filename"
+      unless consumed?(name)
+        skipped[name] = family_of(name)
         next
       end
 
@@ -283,19 +288,37 @@ end
 # upstream happens to rebuild it. So a consumed asset is never removed here,
 # however old it gets.
 def prune
-  doomed = Dir.children(ROOT).reject { |name| consumed?(name) || ours?(name) }
-              .select { |name| File.file?(File.join(ROOT, name)) }
-  return if doomed.empty?
+  # Sized once, in one pass, and tolerant of a name that is gone by the time we
+  # stat it. Nothing else should be writing here -- the lock sees to that --
+  # but this runs last, after the fetches, and taking the whole run down over
+  # one unreadable file would lose the state file written below it and force
+  # 4GB of re-hashing on the next run.
+  sizes = {}
+  Dir.children(ROOT).each do |name|
+    next if consumed?(name) || ours?(name)
 
-  bytes = doomed.sum { |name| File.size(File.join(ROOT, name)) }
-  doomed.group_by { |name| family_of(name) }.sort_by { |_, names| -names.size }.each do |family, names|
+    path = File.join(ROOT, name)
+    sizes[name] = File.size(path) if File.file?(path)
+  rescue SystemCallError => e
+    log "  cannot stat #{name.inspect}: #{e.message}"
+  end
+  return if sizes.empty?
+
+  sizes.keys.group_by { |name| family_of(name) }.sort_by { |_, names| -names.size }.each do |family, names|
     log format('  %s %d %s* (%.1f MB)', DRY_RUN ? 'would remove' : 'removing', names.size, family,
-               names.sum { |n| File.size(File.join(ROOT, n)) } / 1048576.0)
+               names.sum { |n| sizes[n] } / 1048576.0)
   end
   return if DRY_RUN
 
-  doomed.each { |name| FileUtils.rm_f(File.join(ROOT, name)) }
-  log format('removed %d file(s), %.1f MB', doomed.size, bytes / 1048576.0)
+  removed = sizes.keys.count do |name|
+    FileUtils.rm_f(File.join(ROOT, name))
+    true
+  rescue SystemCallError => e
+    log "  cannot remove #{name.inspect}: #{e.message}"
+    false
+  end
+  log format('removed %d of %d file(s), %.1f MB', removed, sizes.size,
+             sizes.values.sum / 1048576.0)
 end
 
 def manifest_missing?(filename)
@@ -341,11 +364,12 @@ with_lock do
   fetched = wanted.count { |a| fetch(a, state) }
   log "fetched #{fetched} of #{wanted.size}"
 
-  prune
-
   # Forget assets the org no longer publishes, so the state file tracks the
   # release set rather than growing forever.
   save_state(state.slice(*assets.keys))
+
+  # Last, so that nothing it might do can cost us the digests just written.
+  prune
 
   # Rebuilding a manifest means listing every tarball, which is the expensive
   # part of a run where nothing changed -- but a manifest that is missing or

--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -41,6 +41,48 @@ ROOT = '/srv/github-releases'
 LOCK = '/run/lock/openipc-mirror-releases.lock'
 TMP_PREFIX = '.tmp-mirror-'
 
+# Generated here from the mirrored tarballs, not fetched. `.kernel.sizes` used
+# to be written alongside and was read by nothing, so it is gone; the prune
+# below removes the copy left on disk.
+MANIFESTS = { '.rootfs.sizes' => 'rootfs' }.freeze
+
+# What the site actually opens. Everything upstream publishes that is not here
+# is skipped, and removed if it is already on disk.
+#
+# An allowlist rather than a list of things to skip: a skip list has to grow
+# every time upstream adds a family, and nobody notices it has not until the
+# disk is full. The opposite failure -- a family we do want that nobody added
+# here -- is the one that bit `plain_filename?` above, so it is made loud
+# rather than left to chance: every skipped family is named in the run's log,
+# once, so a new one appears in the cron mail the morning it first ships.
+#
+# boot-*.bin is here although no SoC currently names one. It is the bootloader
+# under the name the newer parts use, it costs two megabytes, and guessing that
+# upstream will not start using it is the same guess this file already regrets
+# making once.
+CONSUMED = [
+  /\Aopenipc\..+\.tgz\z/,  # Firmware#generate: the kernel and rootfs members
+  /\Au-boot-.+\.bin\z/,     # Firmware#generate: written at offset 0
+  /\Aboot-.+\.bin\z/,       # the same, for parts that name it this way
+  /\Asizes\..+\.json\z/,   # BinariesController
+  /\A_manifest\.json\z/     # which build this is
+].freeze
+
+def consumed?(name)
+  CONSUMED.any? { |pattern| name.match?(pattern) }
+end
+
+# Files this script makes rather than mirrors.
+def ours?(name)
+  name == STATE_FILE || MANIFESTS.key?(name) || name.start_with?(TMP_PREFIX)
+end
+
+# The leading token, so a run reports "skipping 31 toolchain.*" rather than 31
+# lines -- and so a family nobody has seen before is still named.
+def family_of(name)
+  name[/\A[A-Za-z_]+[.-]/] || name
+end
+
 # What we last put on disk, as {name => {size, digest}}. Without it, telling a
 # rebuilt asset from the one already here means hashing 4.3 GB every hour.
 STATE_FILE = '.mirror-state.json'
@@ -117,11 +159,19 @@ def newest_assets
   releases = github.repos.releases.list('openipc', 'firmware',
                                         per_page: RELEASES_PER_PAGE)
   chosen = {}
+  # Names, not counts: an asset published by several releases must be counted
+  # once. `chosen` stays exactly the set we intend to mirror, because its keys
+  # are what the state file is pruned to and what the disk is pruned against.
+  skipped = {}
   releases.each do |release|
     release.assets.each do |asset|
       name = asset['name']
-      next if name.include?('sdk')
-      next if chosen.key?(name)
+      next if chosen.key?(name) || skipped.key?(name)
+
+      unless consumed?(name)
+        skipped[name] = family_of(name)
+        next
+      end
 
       unless plain_filename?(name)
         log "  refusing #{name.inspect} from #{release.tag_name}: not a plain filename"
@@ -137,6 +187,12 @@ def newest_assets
       }
     end
   end
+
+  log format('%d assets published, %d of them consumed here', chosen.size + skipped.size, chosen.size)
+  skipped.values.tally
+         .sort_by { |_, count| -count }
+         .each { |family, count| log format('  skipping %d %s* (nothing here reads them)', count, family) }
+
   chosen
 end
 
@@ -211,6 +267,37 @@ def member_size(tarball, needle)
   nil
 end
 
+# Anything in ROOT the site does not read and this script did not write.
+#
+# Two things end up here. Families skipped on purpose -- 3.1GB of toolchains,
+# the kconfig dumps -- and assets upstream has stopped publishing: 52
+# openipc-<soc>-<flash>-<release>.bin totalling 393MB, all last written
+# 2026-06-13 and carried by no release on the page any more. Without a prune
+# the directory only grows, because nothing here has ever taken a file away.
+#
+# Keyed on what the site reads, deliberately, and not on what upstream still
+# offers. The first attempt did the latter, and its dry run showed it taking
+# openipc.gk7205v210-nor-lite.tgz -- the seventh most requested SoC on the
+# site -- because that build had aged off the first page of releases. A stale
+# tarball still flashes a camera; a missing one is a broken download until
+# upstream happens to rebuild it. So a consumed asset is never removed here,
+# however old it gets.
+def prune
+  doomed = Dir.children(ROOT).reject { |name| consumed?(name) || ours?(name) }
+              .select { |name| File.file?(File.join(ROOT, name)) }
+  return if doomed.empty?
+
+  bytes = doomed.sum { |name| File.size(File.join(ROOT, name)) }
+  doomed.group_by { |name| family_of(name) }.sort_by { |_, names| -names.size }.each do |family, names|
+    log format('  %s %d %s* (%.1f MB)', DRY_RUN ? 'would remove' : 'removing', names.size, family,
+               names.sum { |n| File.size(File.join(ROOT, n)) } / 1048576.0)
+  end
+  return if DRY_RUN
+
+  doomed.each { |name| FileUtils.rm_f(File.join(ROOT, name)) }
+  log format('removed %d file(s), %.1f MB', doomed.size, bytes / 1048576.0)
+end
+
 def manifest_missing?(filename)
   path = File.join(ROOT, filename)
   !File.exist?(path) || File.size(path).zero?
@@ -228,8 +315,6 @@ def write_manifest(filename, needle)
   log "  wrote #{filename} (#{File.readlines(path).size} entries)"
 end
 
-MANIFESTS = { '.rootfs.sizes' => 'rootfs', '.kernel.sizes' => 'uImage' }.freeze
-
 with_lock do
   FileUtils.mkdir_p(ROOT)
 
@@ -244,16 +329,19 @@ with_lock do
   state = load_state
   assets = newest_assets
   wanted = assets.values.reject { |a| current?(File.join(ROOT, a[:name]), a, state) }
-  log "#{assets.size} assets published, #{wanted.size} to fetch"
+  log "#{wanted.size} to fetch"
 
   if DRY_RUN
     wanted.each { |a| log "  would fetch #{a[:name]} (#{a[:size]} bytes, #{a[:release]})" }
+    prune
     log 'dry run, nothing written'
     exit 0
   end
 
   fetched = wanted.count { |a| fetch(a, state) }
   log "fetched #{fetched} of #{wanted.size}"
+
+  prune
 
   # Forget assets the org no longer publishes, so the state file tracks the
   # release set rather than growing forever.


### PR DESCRIPTION
Stage 2 of replacing the eager release mirror with a lazy cache. Host-script only — no Rails code changes, so the running app cannot notice.

## The numbers

`/srv/github-releases` is **4.3 GB**. The site opens **876 MB** of it.

| | files | size | read by |
|---|---:|---:|---|
| `openipc.*.tgz` | 116 | 847.5 MB | `Firmware#generate` |
| `sizes.*.json` | 102 | 3.3 MB | `BinariesController` (Stage 3) |
| `u-boot-*.bin` | 75 | 22.6 MB | `Firmware#generate` |
| `boot-*.bin` | 8 | 2.1 MB | — (see below) |
| `_manifest.json` | 1 | — | provenance |
| **`toolchain.*`** | 31 | **3115.4 MB** | **nothing** |
| **`kconfig-*.json`** | 204 | 2.3 MB | **nothing** |
| **`openipc-*.bin`** | 52 | **392.9 MB** | **nothing — and upstream stopped publishing them** |

That last row was the surprise. 52 pre-assembled `openipc-<soc>-<flash>-<release>.bin`, all last written **2026-06-13**, carried by **no release on the page any more**. They are still here because nothing in this script has ever had a reason to take a file away, only to add one.

## Two changes

**An allowlist of what the site opens**, rather than a list of things to skip. A skip list has to grow every time upstream adds a family, and nobody notices it has not until the disk is full. That trades one failure for the opposite one — a family we *do* want that nobody added — which is exactly what bit `plain_filename?` when it silently stopped mirroring `_manifest.json`. So it is made loud rather than left to chance: **every skipped family is named once per run**, so a new one turns up in the cron mail the morning it first ships.

`boot-*.bin` is on the list although no SoC names one today. It is the bootloader under the name the newer parts use, it costs two megabytes, and betting that upstream will not start using it is the same bet this file already regrets making once.

**A prune**, keyed on what the site reads — *not* on what upstream still offers.

The first version did the latter, and the dry run earned its keep:

```
would remove 2 openipc.* (11.5 MB)
would remove 3 sizes.* (0.1 MB)
```

Those were `openipc.gk7205v210-nor-lite.tgz` — **the seventh most requested SoC on the site, 50 downloads a fortnight** — and `openipc.xm550-nor-lite.tgz`, whose builds had simply aged off the first page of releases. A stale tarball still flashes a camera; a missing one is a broken download until upstream happens to rebuild it. A consumed asset is now **never** removed, however old it gets.

`.kernel.sizes` goes too. It was regenerated on every run that fetched anything, at the cost of a `tar -tv` pass over every tarball, and read by nothing.

## Verification

Precondition checked first: **nothing outside the Rails app serves or reads this directory.** nginx serves only `dl/`, `files/`, `images/` and acme challenges — confirmed with `grep -R` (`grep -r` misses it, `sites-enabled` entries are symlinks), and by fetching a toolchain path against all three vhosts. `deploy/backup-db.sh` and `deploy/RESTORE.md` already declare the directory as not-backed-up and refreshed from GitHub, so it is explicitly a cache with no archival role.

Every filename on disk was then classified by the actual code (regexes read out of the script, not retyped):

```
KEEP  302   openipc. 116 · sizes. 102 · u- 75 · boot- 8 · _manifest. 1
OURS    2   .mirror-state.json · .rootfs.sizes
DROP  288   kconfig- 204 · openipc- 52 · toolchain. 31 · .kernel.sizes 1
```

And `--dry-run` against the production directory:

```
495 assets published, 297 of them consumed here
  skipping 198 kconfig-* (nothing here reads them)
0 to fetch
  would remove 204 kconfig-* (2.3 MB)
  would remove 52 openipc-* (392.9 MB)
  would remove 31 toolchain.* (3115.4 MB)
  would remove 1 .kernel.sizes* (0.0 MB)
dry run, nothing written
```

**3.43 GB removed, 4.3 GB → ~876 MB, and none of the 302 files the site reads is touched.**

## Rollout

The script is deployed by updating the checkout at `/srv/www/deploy-src` that `/usr/local/sbin/openipc-mirror-releases` symlinks to — not by an image deploy. Run `--dry-run` once more on the host after merge, read the list, then let the hourly cron do it. Reverting is re-checking-out the previous script; the deleted files come back from GitHub on the next run for anything consumed (nothing consumed is deleted, so in practice nothing needs to come back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn