### PR TITLE
Give each firmware test its own cache directory

### DIFF
--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -22,6 +22,18 @@ class Firmware
   # testable without a minute-long test, and tunable on a host without a deploy.
   class << self
     attr_accessor :lock_timeout
+
+    # Where assembled images are cached. Settable so each test gets a
+    # directory of its own: the suite parallelises across processes that share
+    # one filesystem, and five tests generate the same NAND filename, so one
+    # test's teardown was deleting a file another was still asserting on.
+    # Resolved lazily -- Rails.root is not available while this class body runs
+    # under eager loading.
+    def cache_dir
+      @cache_dir ||= Rails.root.join('public', 'files')
+    end
+
+    attr_writer :cache_dir
   end
   self.lock_timeout = 60
 
@@ -56,7 +68,7 @@ class Firmware
   end
 
   def filepath
-    @filepath ||= File.join(Rails.root, 'public', 'files', filename)
+    @filepath ||= File.join(self.class.cache_dir, filename)
   end
 
   def nand?

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -36,12 +36,19 @@ class FirmwareTest < ActiveSupport::TestCase
 
   def setup
     @dir = Dir.mktmpdir
-    @generated = []
+    # Each test caches into a directory of its own. The suite parallelises
+    # across processes that share one filesystem, and several tests generate
+    # the same filename -- five of them produce
+    # openipc-hi3516ev300-nand-ultimate.bin -- so without this one test's
+    # teardown deletes a file another is still reading.
+    @cache = Dir.mktmpdir
+    Firmware.cache_dir = @cache
   end
 
   def teardown
+    Firmware.cache_dir = nil
     FileUtils.remove_entry(@dir)
-    @generated.each { |f| FileUtils.rm_f(f) }
+    FileUtils.remove_entry(@cache)
   end
 
   def write_tgz(name, members)
@@ -63,11 +70,7 @@ class FirmwareTest < ActiveSupport::TestCase
   def build(model:, vendor:, members:, flash_type:, size:, release: 'ultimate', board: nil)
     soc = StubSoc.new(model: model, vendor: vendor, board: board, uboot_file: uboot_path,
                       linux_file: write_tgz("openipc.#{board || model}-#{flash_type}-#{release}.tgz", members))
-    fw = Firmware.new(size: size, flash_type: flash_type, release: release, soc: soc)
-    @generated << fw.filepath
-    @generated << File.join(File.dirname(fw.filepath), ".#{fw.filename}.lock")
-    FileUtils.rm_f(fw.filepath)
-    fw
+    Firmware.new(size: size, flash_type: flash_type, release: release, soc: soc)
   end
 
   # Half-built images are named for their target, so a leftover is attributable


### PR DESCRIPTION
CI failed on a branch that changed **no Ruby at all** (#74, a host-script-only change):

```
FirmwareTest#test_only_the_members_needed_are_read_into_memory:
Errno::ENOENT @ rb_file_s_size - public/files/openipc-hi3516ev300-nand-ultimate.bin
```

## Cause

The suite parallelises across processes once it passes fifty tests, and those processes share one filesystem. Ten tests across three groups generate a filename some other test also generates:

```
openipc-hi3516ev300-nand-ultimate.bin      5 tests
openipc-hi3516ev200-nor-ultimate-8mb.bin   3 tests
openipc-ssc338q-nand-ultimate.bin          2 tests
```

So one test's `teardown` deletes a file another is still reading. It fails perhaps one run in three, on whichever test loses — which is why it went green on #73 and red here.

Two of the three groups predate any recent work; the suite crossing the fifty-test parallelisation threshold is what turned a latent collision into a flake.

## Fix

Renaming the models apart would work until the next test picks a name already in use, and the member names inside each tarball are tied to the model, so it is more edit than it looks.

Instead `Firmware.cache_dir` becomes settable and each test points it at a directory of its own. Nothing can collide, and the tests stop having to clean up after themselves — the tmpdir goes in `teardown` and takes the images and lock files with it, so the `@generated` bookkeeping disappears.

The default is unchanged (`Rails.root/public/files`, confirmed via `rails runner`) and resolved lazily, because `Rails.root` is not available while the class body runs under eager loading. Stage 5 of the release-cache work wants a configurable cache root anyway.

## Verification

Six consecutive full runs, 24 parallel processes: `58 runs, 145 assertions, 0 failures, 0 errors` every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn