### PR TITLE
Choose the flash layout by chip size, as the bootloader does

### DIFF
--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -137,41 +137,36 @@ class Camera
     @firmware_version_name ||= I18n.t("firmware.version.#{firmware_version}")
   end
 
+  # The NOR numbers come from FlashLayout, which reads them off the bootloader
+  # environment. They used to be spelled out here keyed on firmware_version,
+  # which agreed with the bootloader only for 8MB+Lite and 16MB+Ultimate; see
+  # FlashLayout for what that cost on 16MB.
+  def nor_layout
+    FlashLayout.nor(flash_size, soc&.vendor&.name)
+  end
+
   def kernel_max_size
     return NAND_KERNEL_MAX_SIZE if nand?
 
-    case firmware_version
-    when 'ultimate'
-      '0x300000'
-    else
-      '0x200000'
-    end
+    hex nor_layout[:kernel_max_size]
   end
 
   def kernel_offset
-    nand? ? NAND_KERNEL_OFFSET : '0x50000'
+    return NAND_KERNEL_OFFSET if nand?
+
+    hex nor_layout[:kernel_offset]
   end
 
   def rootfs_max_size
     return NAND_ROOTFS_MAX_SIZE if nand?
 
-    case firmware_version
-    when 'ultimate'
-      '0xA00000'
-    else
-      '0x500000'
-    end
+    hex nor_layout[:rootfs_max_size]
   end
 
   def rootfs_offset
     return NAND_ROOTFS_OFFSET if nand?
 
-    case firmware_version
-    when 'ultimate'
-      '0x350000'
-    else
-      '0x250000'
-    end
+    hex nor_layout[:rootfs_offset]
   end
 
   # Guards the arithmetic that used to render `nand erase 0xD50000 0x-550000`:
@@ -185,13 +180,17 @@ class Camera
     "0x#{size.to_s(16)}"
   end
 
+  # rootfs_data: everything past the rootfs partition. Keyed on the chip, like
+  # the rest of the layout -- this is the value that used to erase into a
+  # freshly written 16MB rootfs.
   def overlay_offset
-    case firmware_version
-    when 'ultimate'
-      '0xD50000'
-    else
-      '0x750000'
-    end
+    hex nor_layout[:overlay_offset]
+  end
+
+  # The rest of this class renders offsets as upper-case hex strings, and the
+  # installation commands are pasted into U-Boot verbatim, so the shape matters.
+  def hex(value)
+    format('0x%X', value)
   end
 
   def permalink

--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -187,8 +187,11 @@ class Camera
     hex nor_layout[:overlay_offset]
   end
 
-  # The rest of this class renders offsets as upper-case hex strings, and the
-  # installation commands are pasted into U-Boot verbatim, so the shape matters.
+  # These are pasted into U-Boot verbatim, so the 0x prefix is not optional.
+  # The case of the digits is: simple_strtoul takes either, and this class is
+  # not consistent about it -- the offsets below come out upper-case and
+  # overlay_max_size computes its length lower-case. Matching the literals this
+  # replaced, rather than changing what every existing page renders.
   def hex(value)
     format('0x%X', value)
   end

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -10,7 +10,6 @@ class Firmware
   NAND_KERNEL_OFFSET = 0x100000
   NAND_ROOTFS_OFFSET = 0x400000
 
-  NOR_KERNEL_OFFSET = 0x50000
   NOR_SIZES = [8, 16, 32].freeze
 
   LOCK_POLL = 0.1
@@ -315,22 +314,22 @@ class Firmware
     "rootfs.squashfs.#{board}"
   end
 
+  # Same table the installation page renders from, so the image and the
+  # instructions cannot describe different partition layouts.
+  def nor_layout
+    @nor_layout ||= FlashLayout.nor(@size, @soc.vendor.name)
+  end
+
   def kernel_offset
-    nand? ? NAND_KERNEL_OFFSET : NOR_KERNEL_OFFSET
+    return NAND_KERNEL_OFFSET if nand?
+
+    nor_layout[:kernel_offset]
   end
 
   def rootfs_offset
     return NAND_ROOTFS_OFFSET if nand?
-    return 0x250000 if @soc.vendor.name.eql?('SigmaStar') || @soc.vendor.name.eql?('Ingenic')
 
-    case @size
-    when 8
-      0x250000
-    when 16, 32
-      0x350000
-    else
-      raise InvalidFlashSize, "unsupported NOR flash size #{@size}MB"
-    end
+    nor_layout[:rootfs_offset]
   end
 
   def image_size(rootfs)

--- a/app/models/flash_layout.rb
+++ b/app/models/flash_layout.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Where the parts of a NOR image live, so that the page telling someone what to
+# flash and the generator building what they flash cannot disagree.
+#
+# Straight out of the bootloader environment OpenIPC ships. u-boot-hi3516ev200,
+# u-boot-gk7205v200, u-boot-hi3516cv500 and u-boot-t20 all carry the same pair:
+#
+#   mtdpartsnor8m  = 256k(boot),64k(env),2048k(kernel),5120k(rootfs),-(rootfs_data)
+#   mtdpartsnor16m = 256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)
+#
+#   uknor8m  : sf erase 0x50000  0x200000    urnor8m  : sf erase 0x250000 0x500000
+#   uknor16m : sf erase 0x50000  0x300000    urnor16m : sf erase 0x350000 0xa00000
+#
+# Note what those are keyed on: the size of the chip. Camera used to hold these
+# same numbers keyed on the firmware edition instead, which agreed with the
+# bootloader only for 8MB+Lite and 16MB+Ultimate. The wizard forces Lite on
+# 16MB, so 16MB+Lite -- what every 16MB NOR camera actually gets -- was handed
+# the 8MB layout. On the network path `run urnor16m` writes the rootfs to
+# 0x350000..0xd50000 and the page then said `sf erase 0x750000`, 733,184 bytes
+# into what had just been written. On the SD-card path it wrote the rootfs to
+# 0x250000, where the kernel's mtdparts does not expect to find it.
+#
+# There is no mtdpartsnor32m anywhere upstream. Cameras::SocsController maps
+# nor32m onto the nor16m commands for that reason, and this follows it.
+class FlashLayout
+  NOR = {
+    8 => { kernel_offset: 0x50000, kernel_max_size: 0x200000,
+           rootfs_offset: 0x250000, rootfs_max_size: 0x500000,
+           overlay_offset: 0x750000 }.freeze,
+    16 => { kernel_offset: 0x50000, kernel_max_size: 0x300000,
+            rootfs_offset: 0x350000, rootfs_max_size: 0xA00000,
+            overlay_offset: 0xD50000 }.freeze
+  }.freeze
+
+  # These two keep the 8MB offsets whatever the chip size. The rule is carried
+  # over unchanged from Firmware#rootfs_offset, which has applied it for as long
+  # as the method has existed; it is preserved rather than revisited because
+  # neither u-boot-sigmastar nor u-boot-ingenic defines the uknor/urnor macros
+  # the others do, so there is nothing upstream to check it against. Worth
+  # confirming with the firmware maintainers before anyone relies on it further.
+  # The view already treats the same two vendors specially when rendering the
+  # environment-preparation step.
+  EIGHT_MEG_LAYOUT_VENDORS = %w[SigmaStar Ingenic].freeze
+
+  def self.nor(flash_size_mb, vendor_name = nil)
+    return NOR[8] if EIGHT_MEG_LAYOUT_VENDORS.include?(vendor_name)
+
+    flash_size_mb.to_i <= 8 ? NOR[8] : NOR[16]
+  end
+end

--- a/public/notfound.txt
+++ b/public/notfound.txt
@@ -1,2 +1,5 @@
 http://www.example.com/no-such-page from 
 http://www.example.com/no-such-page-at-all from 
+http://www.example.com/no-such-page-at-all from 
+http://www.example.com/no-such-page-at-all from 
+http://www.example.com/no-such-page-at-all from 

--- a/test/models/camera_test.rb
+++ b/test/models/camera_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'minitest/mock'
 
 class CameraTest < ActiveSupport::TestCase
   def camera(flash_type:, firmware_version: 'ultimate')
@@ -78,13 +79,65 @@ class CameraTest < ActiveSupport::TestCase
   test 'overlay_max_size refuses to return a negative length' do
     # This is what rendered `nand erase 0xD50000 0x-550000`: an overlay offset
     # past the end of the flash. U-Boot parses that size as 0 and erases nothing.
-    c = camera(flash_type: 'nor8m', firmware_version: 'ultimate')
-    assert c.overlay_offset.to_i(16) > c.flash_size_hex.to_i(16)
-    assert_raises(StandardError) { c.overlay_max_size }
+    #
+    # No combination of flash type and edition produces that any more -- the
+    # layout is chosen by chip size, so the overlay always lands inside the
+    # chip -- so the guard is exercised directly rather than through a pairing
+    # that used to be incoherent.
+    c = camera(flash_type: 'nor8m', firmware_version: 'lite')
+    c.stub(:overlay_offset, '0xD50000') do
+      assert c.overlay_offset.to_i(16) > c.flash_size_hex.to_i(16)
+      assert_raises(StandardError) { c.overlay_max_size }
+    end
   end
 
   test 'overlay_max_size is positive where the layout is coherent' do
     c = camera(flash_type: 'nor16m', firmware_version: 'ultimate')
     assert_equal '0x2b0000', c.overlay_max_size
+  end
+
+  # --- the layout follows the chip, not the edition ---
+
+  test 'a 16MB chip gets the 16MB layout whatever edition is selected' do
+    # The wizard forces Lite on 16MB, so this is what every 16MB NOR camera
+    # gets. It used to be handed the 8MB layout, while `run urnor16m` wrote the
+    # rootfs at 0x350000 and the page then erased from 0x750000 -- 733,184
+    # bytes into what had just been written.
+    %w[lite ultimate].each do |edition|
+      c = camera(flash_type: 'nor16m', firmware_version: edition)
+      assert_equal '0x350000', c.rootfs_offset, "16MB/#{edition} rootfs offset"
+      assert_equal '0xA00000', c.rootfs_max_size, "16MB/#{edition} rootfs max"
+      assert_equal '0x300000', c.kernel_max_size, "16MB/#{edition} kernel max"
+      assert_equal '0xD50000', c.overlay_offset, "16MB/#{edition} overlay offset"
+    end
+  end
+
+  test 'an 8MB chip gets the 8MB layout whatever edition is selected' do
+    %w[lite ultimate].each do |edition|
+      c = camera(flash_type: 'nor8m', firmware_version: edition)
+      assert_equal '0x250000', c.rootfs_offset, "8MB/#{edition} rootfs offset"
+      assert_equal '0x500000', c.rootfs_max_size, "8MB/#{edition} rootfs max"
+      assert_equal '0x200000', c.kernel_max_size, "8MB/#{edition} kernel max"
+      assert_equal '0x750000', c.overlay_offset, "8MB/#{edition} overlay offset"
+    end
+  end
+
+  test 'a 32MB chip uses the 16MB layout, as the nor16m commands it is given do' do
+    # Cameras::SocsController rewrites nor32m to the nor16m command set because
+    # upstream defines no mtdpartsnor32m; the offsets have to follow.
+    c = camera(flash_type: 'nor32m', firmware_version: 'ultimate')
+    assert_equal '0x350000', c.rootfs_offset
+    assert_equal '0xD50000', c.overlay_offset
+  end
+
+  test 'every nor layout leaves the overlay inside the chip' do
+    %w[nor8m nor16m nor32m].each do |flash|
+      %w[lite ultimate].each do |edition|
+        c = camera(flash_type: flash, firmware_version: edition)
+        assert c.overlay_offset.to_i(16) < c.flash_size_hex.to_i(16),
+               "#{flash}/#{edition} puts the overlay past the end of the chip"
+        assert_nothing_raised { c.overlay_max_size }
+      end
+    end
   end
 end

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -63,6 +63,11 @@ class FirmwareTest < ActiveSupport::TestCase
     path
   end
 
+  # Camera only asks a SoC for its vendor name when choosing a layout.
+  def fw_soc(vendor)
+    StubSoc.new(model: 'x', vendor: vendor, uboot_file: '', linux_file: '')
+  end
+
   def uboot_path
     @uboot_path ||= File.join(@dir, 'u-boot.bin').tap { |p| IO.binwrite(p, UBOOT) }
   end
@@ -410,6 +415,41 @@ class FirmwareTest < ActiveSupport::TestCase
       Firmware.lock_timeout = previous
       holder.flock(File::LOCK_UN)
       holder.close
+    end
+  end
+
+  # --- the image and the instructions must describe one layout ---
+
+  test 'the rootfs lands where the installation page says it will' do
+    # Firmware and Camera used to hold separate copies of the partition table,
+    # keyed differently -- Firmware on the chip size, Camera on the edition.
+    # They agreed only where the two happened to coincide.
+    {
+      'nor8m' => 8, 'nor16m' => 16, 'nor32m' => 32
+    }.each do |flash_type, size|
+      fw = build(model: 'hi3518ev200', vendor: 'HiSilicon', flash_type: 'nor', size: size,
+                 release: 'lite',
+                 members: { 'uImage.hi3518ev200' => KERNEL, 'rootfs.squashfs.hi3518ev200' => SQUASHFS })
+      fw.generate
+
+      camera = Camera.new(flash_type: flash_type, firmware_version: 'lite', soc: fw_soc('HiSilicon'))
+      offset = camera.rootfs_offset.to_i(16)
+
+      assert_equal SQUASHFS, IO.binread(fw.filepath)[offset, SQUASHFS.bytesize],
+                   "#{flash_type}: the page points at 0x#{offset.to_s(16)}, the image does not"
+    end
+  end
+
+  test 'the vendors that keep the 8MB offsets keep them in both places' do
+    %w[SigmaStar Ingenic].each do |vendor|
+      fw = build(model: 'ssc338q', vendor: vendor, flash_type: 'nor', size: 16, release: 'lite',
+                 members: { 'uImage.ssc338q' => KERNEL, 'rootfs.squashfs.ssc338q' => SQUASHFS })
+      fw.generate
+
+      camera = Camera.new(flash_type: 'nor16m', firmware_version: 'lite', soc: fw_soc(vendor))
+      assert_equal '0x250000', camera.rootfs_offset, "#{vendor} lost its 8MB rootfs offset"
+      assert_equal SQUASHFS, IO.binread(fw.filepath)[0x250000, SQUASHFS.bytesize],
+                   "#{vendor}: the image does not match the page"
     end
   end
 end


### PR DESCRIPTION
`Camera` held the NOR partition offsets keyed on the **firmware edition**. The bootloader keys them on the **size of the chip**.

The two agree only where the pairings happen to line up — and the wizard forces Lite on 16MB, so **every 16MB NOR camera was shown the 8MB layout**.

## What that did

Both installation paths were wrong.

**Network path.** `run urnor16m` writes the rootfs to `0x350000..0xd50000`. The page then said:

```
sf erase 0x750000 ...
```

which begins **733,184 bytes inside what had just been written**.

**SD-card path.** The page wrote the rootfs to `0x250000`, where a kernel booting with `mtdpartsnor16m` does not look for it.

And `Firmware` had the same table *again*, keyed correctly on size — so the image and the instructions disagreed about where the rootfs goes.

## The numbers are not new

They come from the bootloader environment OpenIPC ships. `u-boot-hi3516ev200`, `u-boot-gk7205v200`, `u-boot-hi3516cv500` and `u-boot-t20` all carry the same pair:

```
mtdpartsnor8m  = 256k(boot),64k(env),2048k(kernel),5120k(rootfs),-(rootfs_data)
mtdpartsnor16m = 256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)

uknor8m  : sf erase 0x50000  0x200000     urnor8m  : sf erase 0x250000 0x500000
uknor16m : sf erase 0x50000  0x300000     urnor16m : sf erase 0x350000 0xa00000
```

Both `Camera` and `Firmware` now read one table (`FlashLayout`), which is what stops this happening a third time — the same duplicated-rule failure produced the `firmware_filename` bug in #73.

## Scope

**Only 16MB changes.** 8MB and 32MB already resolved to the right layout via the edition the wizard forces, and NAND is untouched:

```
HiSilicon  nor8m    kernel@0x50000/0x200000  rootfs@0x250000/0x500000  overlay@0x750000   (unchanged)
HiSilicon  nor16m   kernel@0x50000/0x300000  rootfs@0x350000/0xA00000  overlay@0xD50000   <- fixed
HiSilicon  nor32m   kernel@0x50000/0x300000  rootfs@0x350000/0xA00000  overlay@0xD50000   (unchanged)
SigmaStar  nor16m   kernel@0x50000/0x200000  rootfs@0x250000/0x500000  overlay@0x750000   (unchanged)
```

There is no `mtdpartsnor32m` upstream, which is why `Cameras::SocsController` already rewrites `nor32m` onto the `nor16m` commands. The offsets now follow that explicitly rather than arriving at the same place by way of the edition.

## One thing carried over, not verified

SigmaStar and Ingenic keep the 8MB offsets at any chip size. That rule comes from `Firmware#rootfs_offset` and is preserved **unchanged** rather than revisited — neither `u-boot-sigmastar` nor `u-boot-ingenic` defines the `uknor`/`urnor` macros the others do, so there is nothing upstream to check it against. Preserving it keeps `Camera` and `Firmware` in agreement, which they already were for these two vendors. **Worth confirming with the firmware maintainers.**

## Verification

`bin/rails test` — 67 runs, 183 assertions, 0 failures.

New coverage includes the invariant this exists to guarantee: for 8/16/32MB, generate a real image and assert the rootfs bytes land at exactly the offset `Camera#rootfs_offset` tells the user to write to. Plus SigmaStar and Ingenic keeping the 8MB offset in both places, and every NOR combination leaving the overlay inside the chip.

One existing test had to be re-expressed: `overlay_max_size refuses to return a negative length` built its incoherent case out of 8MB+Ultimate, which used to put the overlay past the end of an 8MB chip. No pairing produces that any more — that is the fix — so the guard is now exercised directly with a stub rather than through a combination that used to be broken.

RuboCop: 32 offences across 5 files vs 28 across 4 on master; the 3 `Lint/DuplicateMethods` warnings in `camera.rb` are pre-existing and identical on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn