### PR TITLE
Ignore the firmware lock files too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,12 @@
 /public/assets
 
 # Ignore generated binaries
+# Firmware#generate writes here: the assembled images, and a lock file per
+# image so two requests cannot build the same one at once. *.bin already
+# covers the images and the half-built .tmp-<image>-*.bin files; the locks are
+# named .<image>.bin.lock and need their own line.
 /public/files/*.bin
+/public/files/*.lock
 
 # Written by an older route_not_found; kept ignored so a stale copy on a
 # developer machine is never committed again.


### PR DESCRIPTION
`/public/files/*.bin` covers the assembled images and the half-built `.tmp-<image>-*.bin` files, but not the per-image locks `Firmware#generate` takes — those are named `.<image>.bin.lock`. Running the app locally leaves them behind as untracked files.

That is the same shape as the two accidental commits of `public/notfound.txt` in #76 and #78: a runtime artifact under `public/` that `git add -A` picks up. Both were caught in review and both times the content was harmless, but the cheap fix is to stop the directory being able to produce a surprise at all.

## Verification

```
$ git check-ignore -v public/files/.openipc-hi3518ev200-nor-lite-8mb.bin.lock \
                      public/files/.tmp-openipc-hi3518ev200-nor-lite-8mb.bin-abc123.bin \
                      public/files/openipc-hi3518ev200-nor-lite-8mb.bin
.gitignore:36:/public/files/*.lock   public/files/.openipc-hi3518ev200-nor-lite-8mb.bin.lock
.gitignore:35:/public/files/*.bin    public/files/.tmp-openipc-hi3518ev200-nor-lite-8mb.bin-abc123.bin
.gitignore:35:/public/files/*.bin    public/files/openipc-hi3518ev200-nor-lite-8mb.bin
```

No runtime effect — `.gitignore` is not shipped in the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn