### PR TITLE
Publish firmware images readable by the web server

### DIFF
--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -103,12 +103,26 @@ class Firmware
 
   private
 
-  # file exists, is the size it claims to be, and is newer than any of its parts
+  # file exists, can be served, is the size it claims to be, and is newer than
+  # any of its parts
   def fresh?(uboot_file, linux_file)
     File.exist?(filepath) &&
+      web_readable? &&
       right_size? &&
       File.mtime(uboot_file) < File.mtime(filepath) &&
       File.mtime(linux_file) < File.mtime(filepath)
+  end
+
+  # nginx serves this directory and runs as neither the owner nor the group, so
+  # an image it cannot read is not usable even though it is present. Counting
+  # that as stale rebuilds the images published at 0600 before the mode was
+  # fixed, instead of needing a chmod by hand -- and closes the gap between the
+  # rename and the chmod above, where the file exists but is not yet servable.
+  def web_readable?
+    return true if (File.stat(filepath).mode & 0o004).positive?
+
+    Rails.logger.warn "firmware: rebuilding #{filename}, the web server cannot read the cached copy"
+    false
   end
 
   # A NOR image is exactly its flash size by construction, so anything else is
@@ -178,10 +192,16 @@ class Firmware
     # published here was readable only by the app's own user. nginx runs as
     # www-data and serves this directory, so /files/ answered 403 for all of
     # them -- and nothing could hand a download off to nginx while that was
-    # true. Set before the rename, so the file is readable the moment it
-    # appears under its real name.
-    File.chmod(0o644, tmp.path)
+    # true.
+    #
+    # Widened after the rename rather than before it. The temporary file lives
+    # in the same served directory, and there is no reason for a half-built
+    # image to be readable by anything, however unguessable its name and
+    # however short its life. `fresh?` refuses an image the web server cannot
+    # read, so the moment between the two is not one another request can be
+    # served out of.
     File.rename(tmp.path, filepath)
+    File.chmod(0o644, filepath)
   ensure
     # `ensure` rather than `rescue StandardError`, so an Interrupt or a
     # SignalException clears up after itself too. After the rename the path is

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -173,6 +173,14 @@ class Firmware
     tmp.close
     IO.binwrite tmp.path, ("\xFF" * size)
     parts.each { |part| IO.binwrite tmp.path, part.bytes, part.offset }
+
+    # Tempfile creates at 0600 and rename keeps the mode, so every image ever
+    # published here was readable only by the app's own user. nginx runs as
+    # www-data and serves this directory, so /files/ answered 403 for all of
+    # them -- and nothing could hand a download off to nginx while that was
+    # true. Set before the rename, so the file is readable the moment it
+    # appears under its real name.
+    File.chmod(0o644, tmp.path)
     File.rename(tmp.path, filepath)
   ensure
     # `ensure` rather than `rescue StandardError`, so an Interrupt or a

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -381,6 +381,36 @@ class FirmwareTest < ActiveSupport::TestCase
     assert_equal '644', format('%o', File.stat(fw.filepath).mode & 0o777)
   end
 
+  test 'a cached image the web server cannot read is rebuilt, not served' do
+    # Thirty images were published at 0600 before the mode was fixed. Counting
+    # those as stale mends them on first request rather than by hand.
+    fw = build(model: 'ssc30kq', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.ssc30kq' => KERNEL, 'rootfs.squashfs.ssc30kq' => SQUASHFS })
+    fw.generate
+    File.chmod(0o600, fw.filepath)
+
+    fw.generate
+
+    assert_equal '644', format('%o', File.stat(fw.filepath).mode & 0o777)
+  end
+
+  test 'a half-built image is never readable by the web server' do
+    # The temporary file shares the served directory with the image, so it must
+    # not be widened until it is complete and has its real name.
+    fw = build(model: 'hi3516cv200', vendor: 'HiSilicon', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.hi3516cv200' => KERNEL, 'rootfs.squashfs.hi3516cv200' => SQUASHFS })
+
+    seen = []
+    original = File.method(:rename)
+    File.stub(:rename, lambda { |from, to|
+      seen << (File.stat(from).mode & 0o004)
+      original.call(from, to)
+    }) { fw.generate }
+
+    assert_equal [0], seen, 'the temporary file was world-readable before it was published'
+    assert_equal '644', format('%o', File.stat(fw.filepath).mode & 0o777)
+  end
+
   test 'a second generate reuses the cached image instead of rebuilding it' do
     fw = build(model: 'ssc337', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
                members: { 'uImage.ssc337' => KERNEL, 'rootfs.squashfs.ssc337' => SQUASHFS })

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -370,6 +370,17 @@ class FirmwareTest < ActiveSupport::TestCase
     assert_equal SQUASHFS, IO.binread(fw.filepath)[0x250000, SQUASHFS.bytesize]
   end
 
+  test 'the published image is readable by the web server' do
+    # Tempfile creates at 0600 and rename keeps the mode, so every image was
+    # published readable only by the app's own user. nginx runs as a different
+    # one and serves this directory, so /files/ answered 403 for all of them.
+    fw = build(model: 'gk7202v300', vendor: 'Goke', flash_type: 'nor', size: 8, release: 'lite',
+               members: { 'uImage.gk7202v300' => KERNEL, 'rootfs.squashfs.gk7202v300' => SQUASHFS })
+    fw.generate
+
+    assert_equal '644', format('%o', File.stat(fw.filepath).mode & 0o777)
+  end
+
   test 'a second generate reuses the cached image instead of rebuilding it' do
     fw = build(model: 'ssc337', vendor: 'SigmaStar', flash_type: 'nor', size: 8, release: 'lite',
                members: { 'uImage.ssc337' => KERNEL, 'rootfs.squashfs.ssc337' => SQUASHFS })


### PR DESCRIPTION
`Tempfile.create` makes files at `0600` and `File.rename` keeps the mode, so **every image this has ever published was readable only by the user the app runs as**.

nginx runs as `www-data` and serves that directory, so the autoindex browse someone configured at `location /files/` has never worked:

```
$ curl -o /dev/null -w '%{http_code}' https://openipc.org/files/openipc-hi3516ev200-nor-ultimate-8mb.bin
403

$ stat -c '%a' /srv/www/shared/files/*.bin | sort | uniq -c
     30 600

$ stat -c '%a %U' /srv/www/shared/dl/* | sort | uniq -c        # the directory beside it, which does serve
     14 644 paul
```

Container uid 1000 (`rails`) is host uid 1000 (`paul`), so images land owned by `paul` at `0600`.

## Why now

This is the prerequisite for the rest of Stage 4. `X-Accel-Redirect` hands a download to nginx by naming a file for it to send, which requires nginx to be able to read that file. It cannot today.

Worth noting what turned up while checking that: `Rack::Sendfile` is **already in the middleware stack**, and both `variation` and `map_accel_path` fall back to request headers (`X-Sendfile-Type`, `X-Accel-Mapping`). So the X-Accel step is a pure nginx-config change per vhost — no Rails change, no deploy to toggle it — and if the mapping header is absent, Rack logs and falls through to serving the body normally.

## Ordering, after review

The first version widened the mode *before* the rename. Review pointed out that this makes a half-built image readable while it is still incomplete, in a directory nginx serves. That is real, not theoretical — nginx has no default restriction on dotfiles and no vhost here adds one, confirmed against production with a throwaway probe:

```
a 0644 dotfile under /files/: 200  5 bytes
```

(created, fetched, removed). Unguessable name, ~1s window, so not much of a door — but a partial firmware image should not be fetchable at all, which is the whole point of building under a temporary name.

So the rename goes first and the mode is widened after. That leaves a narrower gap the other way — present under its real name, not yet servable — which `fresh?` now closes by refusing an image the web server cannot read.

**That refusal also removes a manual step**: the thirty images already on the host at `0600` rebuild on first request, rather than needing a `chmod` by hand.

## Verification

`bin/rails test` — 71 runs, 188 assertions, 0 failures. Three tests: the published mode is `644`; a `0600` cached image is rebuilt rather than served; and the temporary file is never world-readable before it is published (asserted by stubbing `File.rename` and checking the mode of what is being renamed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn