### PR TITLE
Publish an index of what upstream has, for the app to read

### DIFF
--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -181,7 +181,9 @@ def newest_assets
 
       # The tag goes into the index and from there into a URL path segment.
       # Same reasoning as plain_filename? above, applied to the other half of
-      # the address.
+      # the address. `tag` rather than release.tag_name is what gets stored
+      # below: these are Hashie mashes, and checking one object while keeping
+      # another is how `asset.size` came to mean the key count.
       tag = release.tag_name.to_s
       unless tag.match?(/\A[A-Za-z0-9._-]+\z/)
         log "  refusing #{name.inspect}: tag #{tag.inspect} is not a plain tag"
@@ -194,7 +196,7 @@ def newest_assets
         size: asset['size'],
         digest: asset['digest'],
         updated_at: asset['updated_at'],
-        release: release.tag_name
+        release: tag
       }
     end
   end
@@ -296,6 +298,15 @@ def write_index(assets)
     end
   }
   File.write(tmp, JSON.pretty_generate(index))
+
+  # Stated rather than inherited from whatever umask cron happens to run with.
+  # It is readable today only because the container runs as the same uid this
+  # script does, which is a coincidence of the deployment rather than a
+  # guarantee -- and firmware images spent years at 0600 for exactly that kind
+  # of reason. Set before the rename, unlike public/files: nothing serves this
+  # directory, so there is no half-written file to expose, and the index is
+  # readable the instant it appears under its real name.
+  File.chmod(0o644, tmp)
   File.rename(tmp, path)
   log "wrote #{INDEX_FILE} (#{index['assets'].size} assets)"
 end

--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -67,7 +67,7 @@ end
 
 # Files this script makes rather than mirrors.
 def ours?(name)
-  name == STATE_FILE || name.start_with?(TMP_PREFIX)
+  [STATE_FILE, INDEX_FILE].include?(name) || name.start_with?(TMP_PREFIX)
 end
 
 # The leading token, so a run reports "skipping 31 toolchain.*" rather than 31
@@ -79,6 +79,9 @@ end
 # What we last put on disk, as {name => {size, digest}}. Without it, telling a
 # rebuilt asset from the one already here means hashing 4.3 GB every hour.
 STATE_FILE = '.mirror-state.json'
+
+# Where the app looks to find out what exists upstream and how to fetch it.
+INDEX_FILE = '.index.json'
 
 # Asset names come from the API and are pasted straight into a path, so a name
 # is refused rather than sanitised unless it is a plain filename: unchanged by
@@ -176,11 +179,21 @@ def newest_assets
         next
       end
 
+      # The tag goes into the index and from there into a URL path segment.
+      # Same reasoning as plain_filename? above, applied to the other half of
+      # the address.
+      tag = release.tag_name.to_s
+      unless tag.match?(/\A[A-Za-z0-9._-]+\z/)
+        log "  refusing #{name.inspect}: tag #{tag.inspect} is not a plain tag"
+        next
+      end
+
       chosen[name] = {
         name: name,
         url: asset['browser_download_url'],
         size: asset['size'],
         digest: asset['digest'],
+        updated_at: asset['updated_at'],
         release: release.tag_name
       }
     end
@@ -249,6 +262,44 @@ def fetch(asset, state)
   true
 end
 
+# What the site is allowed to ask for, and where each thing lives upstream.
+#
+# The app reads this rather than calling the API itself: the API is
+# unauthenticated at 60 requests an hour, shared by every container on the
+# host, and a request path that can exhaust that is a request path that can
+# take downloads out for the rest of the hour. One call an hour from here
+# leaves the whole budget spare.
+#
+# It is also the allowlist. A name that is not in here is one upstream is not
+# publishing, so the app refuses it before it can reach a path or a URL --
+# which matters because those names come from a database column an admin can
+# edit.
+#
+# The download URL is deliberately absent. The reader builds it from a constant
+# base, the release tag and the asset name, all three of which are checked
+# where they are cheap to check -- rather than following a URL handed over by
+# the API. Constructing beats validating.
+#
+# Written .tmp-then-rename so a reader never sees half an index.
+def write_index(assets)
+  path = File.join(ROOT, INDEX_FILE)
+  tmp = "#{path}.tmp"
+  index = {
+    'generated_at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+    'assets' => assets.values.sort_by { |a| a[:name] }.to_h do |a|
+      [a[:name], {
+        'size' => a[:size],
+        'digest' => a[:digest],
+        'updated_at' => a[:updated_at],
+        'release' => a[:release]
+      }]
+    end
+  }
+  File.write(tmp, JSON.pretty_generate(index))
+  File.rename(tmp, path)
+  log "wrote #{INDEX_FILE} (#{index['assets'].size} assets)"
+end
+
 # Anything in ROOT the site does not read and this script did not write.
 #
 # Two things end up here. Families skipped on purpose -- 3.1GB of toolchains,
@@ -312,6 +363,10 @@ with_lock do
   state = load_state
   assets = newest_assets
   wanted = assets.values.reject { |a| current?(File.join(ROOT, a[:name]), a, state) }
+  # Every run, and before the fetches: the index is what the app reads, and it
+  # is cheap. A run that fails to download anything still leaves it current.
+  write_index(assets) unless DRY_RUN
+
   log "#{wanted.size} to fetch"
 
   if DRY_RUN


### PR DESCRIPTION
First step of Stage 5, the lazy release cache. Host script only — no Rails change, nothing reads this yet.

## What and why

The app will need to know what exists upstream, how big it is and what it should hash to, **without asking GitHub on the request path**. The API is unauthenticated at 60 calls/hour, shared by every container on this host, so a request path that can exhaust it is a request path that can take downloads out for the rest of the hour. One call an hour from here leaves the whole budget spare.

The index is also **the allowlist**. Asset names reach the app from a database column an admin can edit, so a name upstream is not publishing must be refused before it can become a path or a URL.

```json
"openipc.ssc338q-nor-lite.tgz": {
  "size": 7883631,
  "digest": "sha256:dc3f9fee73a6541a529d61a1c3551d7a5357632d519ad080e82e1c8db995bee7",
  "updated_at": "2026-08-24T07:52:07Z",
  "release": "nightly"
}
```

**No download URL, deliberately.** The reader builds one from a constant base, the release tag and the asset name — constructing beats validating a URL handed over by the API. The tag now gets the same structural check the asset name has had since this script was rewritten, since it ends up in a URL path segment for the same reason.

Written **every run and before the fetches**, so a run that downloads nothing still leaves it current, and `.tmp`-then-renamed so a reader never sees half an index. Added to `ours?` so the prune does not remove it.

## A wrinkle the reader will have to handle

**22 of the 198 consumed assets carry no digest.** All of them are bootloaders:

```
u-boot-hi3516dv200-universal.bin   234627   updated 2023-03-22
u-boot-t31x-nor.bin                185084   updated 2024-10-27
u-boot-t40xp-universal.bin         235808   updated 2023-04-18
...
```

GitHub only started publishing digests later, and these have not been rebuilt since. Every `openipc.*.tgz` — the ones that actually churn nightly — has a sha256. So the cache can content-address the firmware and will key those 22 on the size upstream advertises, which is exactly what this script already does for them in `current?`.

## Verification

On the production host: `--dry-run` writes nothing (checked the file is absent afterwards); a real run as `paul` writes `.index.json`, 65 KB, 198 assets — 114 `openipc.*`, 75 `u-boot-*`, 8 `boot-*`, 1 `_manifest.json` — owned by `paul`, and it survives the prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn