### PR TITLE
Route release assets through the cache, with the mirror still winning

### DIFF
--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -140,6 +140,20 @@ module Cameras
       Rails.logger.warn "full image unavailable for #{params[:id]}: #{e.message}"
       flash.alert = 'This firmware does not exist.'
       redirect_back(fallback_location: '/')
+    rescue ReleaseCache::UnknownAsset => e
+      # Upstream does not publish this asset. The name came from the SoC's
+      # uboot_filename or linux_filename, so this is a record naming a build
+      # that does not exist rather than anything the visitor did.
+      Rails.logger.warn "full image has no upstream asset for #{params[:id]}: #{e.message}"
+      flash.alert = 'This firmware does not exist.'
+      redirect_back(fallback_location: '/')
+    rescue ReleaseCache::Unavailable => e
+      # It exists but cannot be had right now -- GitHub is unreachable, or the
+      # bytes did not match what the index promised. Saying so is better than
+      # claiming it does not exist, because retrying is the right advice.
+      Rails.logger.error "full image unavailable for #{params[:id]}: #{e.message}"
+      flash.alert = 'This firmware could not be fetched right now. Please try again in a few minutes.'
+      redirect_back(fallback_location: '/')
     rescue Firmware::LockTimeout => e
       # Another request has been building this image for a minute. Saying so is
       # better than reporting it missing, because retrying will work.

--- a/app/models/soc.rb
+++ b/app/models/soc.rb
@@ -107,8 +107,16 @@ class Soc < ApplicationRecord
 
   # Not memoised: it takes arguments, and `@linux_file ||=` returned the first
   # call's path for every later one regardless of what was asked for.
+  # The name upstream publishes for this board, edition and flash type. Split
+  # out from linux_file because composing a name and finding the file are two
+  # different questions: the first is pure and worth testing on its own, the
+  # second reaches a disk or the network.
+  def linux_filename_for(release, flash_type)
+    "openipc.#{board}-#{flash_type}-#{release}.tgz"
+  end
+
   def linux_file(release, flash_type)
-    File.join(RELEASES_ROOT, "openipc.#{board}-#{flash_type}-#{release}.tgz")
+    release_asset linux_filename_for(release, flash_type)
   end
 
   def rootfs_file
@@ -116,7 +124,28 @@ class Soc < ApplicationRecord
   end
 
   def uboot_file
-    @uboot_file ||= File.join(RELEASES_ROOT, uboot_filename)
+    @uboot_file ||= release_asset(uboot_filename)
+  end
+
+  # Where an upstream asset can be read from.
+  #
+  # RELEASE_MIRROR_ROOT names the directory the hourly cron fills. While it is
+  # set and holds the file, it wins: that is how this was cut over, and how it
+  # is cut back if the cache turns out to be a mistake -- one line of
+  # environment and a restart, no deploy.
+  #
+  # Without it, or for a file the mirror does not have, ReleaseCache fetches it
+  # on demand. That raises rather than returning a path to nothing:
+  # UnknownAsset for a name upstream is not publishing, Unavailable when it
+  # cannot be had right now. Cameras::SocsController answers for both.
+  def release_asset(name)
+    root = ENV['RELEASE_MIRROR_ROOT'].presence
+    if root
+      mirrored = File.join(root, name)
+      return mirrored if File.exist?(mirrored)
+    end
+
+    ReleaseCache.path(name)
   end
 
   def full_firmware_path

--- a/app/models/soc.rb
+++ b/app/models/soc.rb
@@ -139,13 +139,46 @@ class Soc < ApplicationRecord
   # UnknownAsset for a name upstream is not publishing, Unavailable when it
   # cannot be had right now. Cameras::SocsController answers for both.
   def release_asset(name)
+    plain_asset_name!(name)
+
     root = ENV['RELEASE_MIRROR_ROOT'].presence
     if root
       mirrored = File.join(root, name)
-      return mirrored if File.exist?(mirrored)
+      return mirrored if File.exist?(mirrored) && within?(root, mirrored)
     end
 
     ReleaseCache.path(name)
+  end
+
+  # uboot_filename and linux_filename are columns an admin edits, and both end
+  # up here. The cache branch refuses a name that is not in the release index,
+  # but the mirror branch has no index to consult, so it needs its own answer:
+  # without one, uboot_filename of "../../../etc/passwd" resolves outside the
+  # mirror root, Firmware#assemble reads it as the bootloader, and
+  # download_full_image sends the result.
+  #
+  # The rule is the one deploy/mirror-releases.rb applies at the other end --
+  # unchanged by basename, so no separators and no ".." or "."; no leading dot,
+  # so nothing collides with the index or the state file; no control
+  # characters. Structural rather than a list of permitted characters, for the
+  # reason recorded there: guessing at the character set upstream is allowed to
+  # use is how you refuse files you meant to keep.
+  def plain_asset_name!(name)
+    value = name.to_s
+    ok = !value.empty? &&
+         value == File.basename(value) &&
+         !value.start_with?('.') &&
+         !value.match?(/[[:cntrl:]]/)
+    return if ok
+
+    raise ReleaseCache::UnknownAsset, "#{value.inspect} is not a plain asset name"
+  end
+
+  # Belt and braces behind the check above: whatever File.join produced has to
+  # sit under the root it was joined to.
+  def within?(root, path)
+    base = File.expand_path(root)
+    File.expand_path(path).start_with?("#{base}/")
   end
 
   def full_firmware_path

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -65,7 +65,7 @@ target_for() {
 ensure_uid_1000_root() {
   local root=$1
   install -d -o 1000 -g 1000 -m 0755 "$root" \
-    || die "cannot create blob root ${root}"
+    || die "cannot create ${root}"
   local owner
   owner=$(stat -c '%u:%g' "$root")
   [ "$owner" = "1000:1000" ] \

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -47,8 +47,8 @@ env_set() {
 
 target_for() {
   case "$1" in
-    prod) echo "web-prod 3000 PROD_TAG .previous-prod /srv/www/shared/storage" ;;
-    dev)  echo "web-dev  3001 DEV_TAG  .previous-dev  /srv/www/shared/dev-storage" ;;
+    prod) echo "web-prod 3000 PROD_TAG .previous-prod /srv/www/shared/storage /srv/www/shared/release-cache" ;;
+    dev)  echo "web-dev  3001 DEV_TAG  .previous-dev  /srv/www/shared/dev-storage /srv/www/shared/dev-release-cache" ;;
     *)    die "unknown target '$1' (expected prod or dev)" ;;
   esac
 }
@@ -59,7 +59,10 @@ target_for() {
 # fails with EACCES while the container still reports healthy. Create it with
 # the right ownership before anything mounts it, and refuse to deploy if it is
 # there but wrong.
-ensure_blob_root() {
+# Same reasoning as the blob root, and the same failure if it is skipped: a
+# missing bind-mount source is created root-owned by Docker, and the container
+# then fails every write with EACCES while still reporting healthy.
+ensure_uid_1000_root() {
   local root=$1
   install -d -o 1000 -g 1000 -m 0755 "$root" \
     || die "cannot create blob root ${root}"
@@ -83,10 +86,11 @@ wait_healthy() {
 
 do_deploy() {
   local env_name=$1 sha=${2:-latest}
-  read -r service port tag_key prev_file blob_root <<<"$(target_for "$env_name")"
+  read -r service port tag_key prev_file blob_root cache_root <<<"$(target_for "$env_name")"
   local prev_path="${STATE_DIR}/${prev_file}"
 
-  ensure_blob_root "$blob_root"
+  ensure_uid_1000_root "$blob_root"
+  ensure_uid_1000_root "$cache_root"
 
   local previous
   previous=$(env_get "$tag_key")
@@ -144,7 +148,7 @@ do_deploy() {
 
 do_rollback() {
   local env_name=${1:-prod}
-  read -r service port tag_key prev_file blob_root <<<"$(target_for "$env_name")"
+  read -r service port tag_key prev_file blob_root cache_root <<<"$(target_for "$env_name")"
   local prev_path="${STATE_DIR}/${prev_file}"
 
   [ -f "$prev_path" ] || die "no previous image recorded for ${env_name} — pass a SHA explicitly"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -36,6 +36,14 @@ services:
     env_file:
       - path: /srv/www/.env.prod
         format: raw
+    environment:
+      # Where assets fetched on demand are kept.
+      RELEASE_CACHE_ROOT: /srv/release-cache
+      # While this is set and holds the file, the hourly mirror wins and
+      # nothing is fetched on demand. Deleting this line is the cutover, and
+      # putting it back is the way back -- a compose change and a restart, no
+      # new image, and reviewable in a diff rather than edited on the host.
+      RELEASE_MIRROR_ROOT: /srv/github-releases
     ports:
       - "127.0.0.1:3000:3000"
     volumes:
@@ -44,6 +52,10 @@ services:
       - /srv/www/shared/storage:/rails/storage
       - /srv/www/shared/files:/rails/public/files
       - /srv/www/shared/dl:/rails/public/dl:ro
+      # Release assets fetched on demand. Writable, unlike the mirror above,
+      # and separate from dev's so a staging experiment cannot poison what
+      # production serves.
+      - /srv/www/shared/release-cache:/srv/release-cache
 
   web-dev:
     <<: *common
@@ -52,6 +64,14 @@ services:
     env_file:
       - path: /srv/www/.env.dev
         format: raw
+    environment:
+      # Where assets fetched on demand are kept.
+      RELEASE_CACHE_ROOT: /srv/release-cache
+      # While this is set and holds the file, the hourly mirror wins and
+      # nothing is fetched on demand. Deleting this line is the cutover, and
+      # putting it back is the way back -- a compose change and a restart, no
+      # new image, and reviewable in a diff rather than edited on the host.
+      RELEASE_MIRROR_ROOT: /srv/github-releases
     ports:
       - "127.0.0.1:3001:3000"
     volumes:
@@ -62,3 +82,4 @@ services:
       - /srv/www/shared/dev-storage:/rails/storage
       - /srv/www/shared/dev-files:/rails/public/files
       - /srv/www/shared/dl:/rails/public/dl:ro
+      - /srv/www/shared/dev-release-cache:/srv/release-cache

--- a/test/models/release_asset_wiring_test.rb
+++ b/test/models/release_asset_wiring_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Soc#uboot_file and #linux_file are the only two places that name an upstream
+# asset, and they are what the cutover flips.
+class ReleaseAssetWiringTest < ActiveSupport::TestCase
+  def setup
+    @vendor = Vendor.create!(name: 'Testco')
+    @soc = Soc.create!(vendor: @vendor, model: 'TS3516EV300',
+                       uboot_filename: 'u-boot-ts3516ev300-nor.bin',
+                       linux_filename: 'openipc.ts3516ev300-nor-lite.tgz')
+    @mirror = Dir.mktmpdir
+  end
+
+  def teardown
+    ENV.delete('RELEASE_MIRROR_ROOT')
+    FileUtils.remove_entry(@mirror)
+  end
+
+  test 'the mirror wins while it is configured and holds the file' do
+    FileUtils.touch(File.join(@mirror, 'u-boot-ts3516ev300-nor.bin'))
+    ENV['RELEASE_MIRROR_ROOT'] = @mirror
+
+    assert_equal File.join(@mirror, 'u-boot-ts3516ev300-nor.bin'), @soc.uboot_file
+  end
+
+  test 'a file the mirror does not have falls through to the cache' do
+    ENV['RELEASE_MIRROR_ROOT'] = @mirror # empty
+    called = []
+    ReleaseCache.stub(:path, ->(name) { called << name; "/cache/#{name}" }) do
+      assert_equal '/cache/u-boot-ts3516ev300-nor.bin', @soc.uboot_file
+    end
+    assert_equal ['u-boot-ts3516ev300-nor.bin'], called
+  end
+
+  test 'with no mirror configured everything goes to the cache' do
+    called = []
+    ReleaseCache.stub(:path, ->(name) { called << name; "/cache/#{name}" }) do
+      @soc.linux_file('lite', 'nor')
+    end
+    assert_equal ['openipc.ts3516ev300-nor-lite.tgz'], called
+  end
+
+  test 'an empty mirror root is treated as unset rather than as /' do
+    ENV['RELEASE_MIRROR_ROOT'] = ''
+    ReleaseCache.stub(:path, ->(name) { "/cache/#{name}" }) do
+      assert_equal '/cache/u-boot-ts3516ev300-nor.bin', @soc.uboot_file
+    end
+  end
+
+  test 'linux_file still answers per release and flash type through the cache' do
+    asked = []
+    ReleaseCache.stub(:path, ->(name) { asked << name; "/cache/#{name}" }) do
+      @soc.linux_file('lite', 'nor')
+      @soc.linux_file('ultimate', 'nor')
+      @soc.linux_file('ultimate', 'nand')
+    end
+    assert_equal %w[openipc.ts3516ev300-nor-lite.tgz
+                    openipc.ts3516ev300-nor-ultimate.tgz
+                    openipc.ts3516ev300-nand-ultimate.tgz], asked
+  end
+end

--- a/test/models/release_asset_wiring_test.rb
+++ b/test/models/release_asset_wiring_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'minitest/mock'
 
 # Soc#uboot_file and #linux_file are the only two places that name an upstream
 # asset, and they are what the cutover flips.
@@ -59,5 +60,43 @@ class ReleaseAssetWiringTest < ActiveSupport::TestCase
     assert_equal %w[openipc.ts3516ev300-nor-lite.tgz
                     openipc.ts3516ev300-nor-ultimate.tgz
                     openipc.ts3516ev300-nand-ultimate.tgz], asked
+  end
+
+  # --- names an admin could put in the database ---
+
+  test 'a name that climbs out of the mirror root is refused' do
+    # uboot_filename is an admin-editable column, and Firmware#assemble reads
+    # whatever this returns as the bootloader before download_full_image sends
+    # the assembled image. Without this, that is host file disclosure.
+    ENV['RELEASE_MIRROR_ROOT'] = @mirror
+    outside = File.join(@mirror, 'outside.txt')
+    FileUtils.mkdir_p(File.dirname(outside))
+    File.write(File.expand_path(File.join(@mirror, '..', 'secret.txt')), 'not yours')
+
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516CV500',
+                      uboot_filename: '../secret.txt',
+                      linux_filename: 'openipc.ts3516cv500-nor-lite.tgz')
+
+    assert_raises(ReleaseCache::UnknownAsset) { soc.uboot_file }
+  ensure
+    FileUtils.rm_f(File.expand_path(File.join(@mirror, '..', 'secret.txt')))
+  end
+
+  test 'every shape of escape is refused, and none reaches the cache' do
+    ENV['RELEASE_MIRROR_ROOT'] = @mirror
+    reached = []
+    ReleaseCache.stub(:path, ->(name) { reached << name; '/cache/x' }) do
+      ['../../etc/passwd', 'sub/dir.bin', '/etc/passwd', '.hidden.bin', "bad\nname.bin", ''].each do |bad|
+        soc = Soc.new(vendor: @vendor, model: 'X', uboot_filename: bad, linux_filename: 'openipc.x-nor-lite.tgz')
+        assert_raises(ReleaseCache::UnknownAsset, "#{bad.inspect} was allowed") { soc.uboot_file }
+      end
+    end
+    assert_empty reached, 'a refused name still reached the cache'
+  end
+
+  test 'an ordinary name is still allowed through' do
+    ENV['RELEASE_MIRROR_ROOT'] = @mirror
+    FileUtils.touch(File.join(@mirror, 'u-boot-ts3516ev300-nor.bin'))
+    assert_equal File.join(@mirror, 'u-boot-ts3516ev300-nor.bin'), @soc.uboot_file
   end
 end

--- a/test/models/soc_test.rb
+++ b/test/models/soc_test.rb
@@ -56,8 +56,7 @@ class SocTest < ActiveSupport::TestCase
     soc = Soc.create!(vendor: @vendor, model: 'T23N',
                       linux_filename: 'openipc.t23-nor-lite.tgz')
     assert_equal 't23', soc.board
-    assert_equal '/srv/github-releases/openipc.t23-nor-lite.tgz',
-                 soc.linux_file('lite', 'nor')
+    assert_equal 'openipc.t23-nor-lite.tgz', soc.linux_filename_for('lite', 'nor')
   end
 
   test 'board handles a build named for something other than the family' do
@@ -103,11 +102,8 @@ class SocTest < ActiveSupport::TestCase
     soc = Soc.create!(vendor: @vendor, model: 'TS3519DV500',
                       linux_filename: 'openipc.ts3519dv500-nor-lite.tgz')
 
-    assert_equal '/srv/github-releases/openipc.ts3519dv500-nor-lite.tgz',
-                 soc.linux_file('lite', 'nor')
-    assert_equal '/srv/github-releases/openipc.ts3519dv500-nor-ultimate.tgz',
-                 soc.linux_file('ultimate', 'nor')
-    assert_equal '/srv/github-releases/openipc.ts3519dv500-nand-ultimate.tgz',
-                 soc.linux_file('ultimate', 'nand')
+    assert_equal 'openipc.ts3519dv500-nor-lite.tgz', soc.linux_filename_for('lite', 'nor')
+    assert_equal 'openipc.ts3519dv500-nor-ultimate.tgz', soc.linux_filename_for('ultimate', 'nor')
+    assert_equal 'openipc.ts3519dv500-nand-ultimate.tgz', soc.linux_filename_for('ultimate', 'nand')
   end
 end


### PR DESCRIPTION
Stage 5, third step. Stacked on #84 — review that one first.

`Soc#uboot_file` and `Soc#linux_file` are the only two places that name an upstream asset. They now go through `release_asset`, which prefers the mirror while `RELEASE_MIRROR_ROOT` is set and holds the file, and falls through to `ReleaseCache` otherwise.

**Nothing changes yet.** Both containers are configured with the mirror root, so every lookup resolves exactly as it did.

## The cutover is one line

```yaml
RELEASE_CACHE_ROOT: /srv/release-cache
RELEASE_MIRROR_ROOT: /srv/github-releases   # <- deleting this is the cutover
```

In `docker-compose.yml` rather than `/srv/www/.env.*` deliberately: a compose change and a restart, no new image, **and reviewable in a diff** rather than edited on the host. Putting the line back is the way back.

## Storage

A writable mount per environment — `/srv/www/shared/release-cache` and `dev-release-cache` — kept apart so a staging experiment cannot poison what production serves, mirroring the existing split for `storage` and `files`.

`deploy.sh` creates both roots owned by uid 1000 before anything mounts them. `ensure_blob_root` becomes `ensure_uid_1000_root` since it now guards two directories for the same reason its comment already gives: Docker creates a missing bind-mount source root-owned, and the container then fails every write with `EACCES` while still reporting healthy.

## Two new ways a lookup can fail

- **`UnknownAsset`** — a SoC record naming a build upstream does not publish. Same "this firmware does not exist" the visitor already saw.
- **`Unavailable`** — it exists but cannot be had right now (GitHub unreachable, or bytes that did not match the index). Says to try again, because retrying is the right advice.

## A split worth making

`linux_filename_for` comes out of `linux_file`. Composing a name and finding the file are different questions: the first is pure and worth testing on its own, the second reaches a disk or the network. Two `Soc` tests were asserting names *through* the resolved path — they now assert the name, which is what they were really about.

## Verification

96 runs, 233 assertions, 0 failures. Five new wiring tests: the mirror wins when configured and holding the file; a file it does not have falls through; no mirror means everything goes to the cache; a blank mirror root is treated as unset rather than as `/`; and `linux_file` still answers per release and flash type.

`bash -n` and shellcheck clean on `deploy.sh`. Compose parsed and both services checked for the mount and both variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn