### PR TITLE
Cut dev over to fetching release assets on demand

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -67,11 +67,8 @@ services:
     environment:
       # Where assets fetched on demand are kept.
       RELEASE_CACHE_ROOT: /srv/release-cache
-      # While this is set and holds the file, the hourly mirror wins and
-      # nothing is fetched on demand. Deleting this line is the cutover, and
-      # putting it back is the way back -- a compose change and a restart, no
-      # new image, and reviewable in a diff rather than edited on the host.
-      RELEASE_MIRROR_ROOT: /srv/github-releases
+      # Cut over: dev fetches on demand. Production still has the line above
+      # while this is watched; putting it back here is the way back.
     ports:
       - "127.0.0.1:3001:3000"
     volumes:


### PR DESCRIPTION
The cutover, for dev only. Production keeps `RELEASE_MIRROR_ROOT` while this is watched.

```yaml
web-prod:  RELEASE_MIRROR_ROOT: /srv/github-releases
web-dev:   (unset — lazy)
```

This is what the last four PRs were building towards. From here dev does not need the hourly cron to have succeeded before somebody can download firmware — which was the fragility worth removing, more than the bandwidth.

## What it changes

`Soc#release_asset` stops finding a mirror root and falls through to `ReleaseCache` for every asset: index lookup, fetch-on-first-want, sha256 or size verification, atomic publish, one fetch per blob across requests and processes.

## Reverting

Put the line back. A compose change and a restart, no new image — which is why it lives here rather than in `/srv/www/.env.*`.

## Verification before merge

Shadow-deployed on dev at `1ecc514` and confirmed inert: `uboot_file` and `linux_file` both still resolved under `/srv/github-releases`, the cache directory held zero files, and downloads returned identical byte counts.

`bin/rails test` — 102 runs, 246 assertions, 0 failures. Compose parsed and both services checked.

## After merge

Deploy dev, then confirm the cache genuinely serves: blobs appear under `/srv/www/shared/dev-release-cache`, downloads still return exact flash sizes, and a cold SoC the mirror never held still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn