### PR TITLE
Cut production over to fetching release assets on demand

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -39,11 +39,10 @@ services:
     environment:
       # Where assets fetched on demand are kept.
       RELEASE_CACHE_ROOT: /srv/release-cache
-      # While this is set and holds the file, the hourly mirror wins and
-      # nothing is fetched on demand. Deleting this line is the cutover, and
-      # putting it back is the way back -- a compose change and a restart, no
-      # new image, and reviewable in a diff rather than edited on the host.
-      RELEASE_MIRROR_ROOT: /srv/github-releases
+      # Cut over: assets are fetched on demand and kept. Restoring
+      # `RELEASE_MIRROR_ROOT: /srv/github-releases` here puts the hourly mirror
+      # back in front, which is the way back -- a compose change and a restart,
+      # no new image.
     ports:
       - "127.0.0.1:3000:3000"
     volumes:


### PR DESCRIPTION
The last `RELEASE_MIRROR_ROOT` goes. Production resolves every upstream asset through `ReleaseCache`.

**This is the goal the whole line of work was for**: nobody now needs an hourly cron — running as `paul`, under system Ruby, with a gem that is not in the `Gemfile` — to have succeeded before they can download firmware.

## Measured on dev, after its own cutover

From a completely cold cache (blobs and assembled images both cleared, container restarted):

```
sigmastar/ssc338q      8mb   200  8388608   0.60s
hisilicon/hi3518ev200 16mb   200 16777216   1.15s
goke/gk7205v300        8mb   200  8388608   1.13s
ingenic/t23n           8mb   200  8388608   1.15s
ingenic/t31x          16mb   200 16777216   1.17s
```

Each figure includes fetching **both** parts from GitHub and assembling the image. The same requests warm: 0.05s and 0.17s.

```
blobs: 10        cache: 35M        mirror: 873M
all content-addressed blobs verify against their own names
```

35 MB of what people actually asked for, against 873 MB fetched on the chance they might.

Also checked on dev: pages answer as before, a SoC whose edition upstream does not build still redirects rather than erroring, and the log shows 11 assets fetched on demand with no errors.

## Reverting

Restore `RELEASE_MIRROR_ROOT: /srv/github-releases` under `web-prod`. A compose change and a restart, no new image.

The mirror keeps running and keeps its files while this is watched, so the way back stays cheap. Retiring the cron, the read-only mount and `/srv/github-releases` itself are separate steps for later.

## Known gap, not a blocker

A mirror run failed during testing with a transient `504` from the GitHub API — not the rate limit, and the retry succeeded. `newest_assets` has no retry, so a transient error aborts the run and with it the index write. A stale index is fine (the app reads whatever is on disk); a never-written one is not. Worth a retry around that call, tracked separately — and until the mirror is retired, the assets are still on disk anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn