### PR TITLE
Retry the releases list before giving up on a run

### DIFF
--- a/deploy/mirror-releases.rb
+++ b/deploy/mirror-releases.rb
@@ -150,10 +150,42 @@ end
 
 # The newest release that publishes each asset name wins. `list` returns
 # releases newest-first, so the first sighting of a name is the freshest.
+# The whole run turns on this one call, and it is the only part of the script
+# with no second chance: curl already retries a download three times, but a
+# release list that fails takes the index with it. Seen on 2026-08-24 --
+#
+#   GET https://api.github.com/repos/openipc/firmware/releases?per_page=30:
+#   504 - Gateway Time-out
+#
+# -- which was transient, and the next attempt succeeded. It was not the rate
+# limit; that showed 57 of 60 remaining.
+#
+# A stale index is harmless, because the app reads whatever is on disk and an
+# asset that has not changed is still addressed correctly by it. A missing one
+# is not, and once the mirror is retired the index is the only thing standing
+# between a visitor and a download.
+#
+# Waits of 5s and 15s: long enough for a gateway hiccup to pass, short enough
+# that three attempts cannot overrun the hour between runs.
+API_RETRY_WAITS = [5, 15].freeze
+
+def releases_page
+  attempt = 0
+  begin
+    Github.new.repos.releases.list('openipc', 'firmware', per_page: RELEASES_PER_PAGE)
+  rescue StandardError => e
+    wait = API_RETRY_WAITS[attempt]
+    raise if wait.nil?
+
+    attempt += 1
+    log "  releases list failed (#{e.class}: #{e.message.to_s.lines.first.to_s.strip}), retrying in #{wait}s"
+    sleep wait
+    retry
+  end
+end
+
 def newest_assets
-  github = Github.new
-  releases = github.repos.releases.list('openipc', 'firmware',
-                                        per_page: RELEASES_PER_PAGE)
+  releases = releases_page
   chosen = {}
   # Names, not counts: an asset published by several releases must be counted
   # once. `chosen` stays exactly the set we intend to mirror, because its keys


### PR DESCRIPTION
The whole mirror run turns on one API call, and it was the only part of the script with **no second chance** — `curl` already retries a download three times, but a releases list that fails takes the index write with it.

Seen during the Stage 5 cutover:

```
GET https://api.github.com/repos/openipc/firmware/releases?per_page=30:
504 - Gateway Time-out
```

Transient — the next attempt succeeded — and **not** the rate limit, which showed 57 of 60 remaining.

## Why it matters more than it did last week

A stale index is harmless: the app reads whatever is on disk, and an asset that has not changed is still addressed correctly by it. A **missing** one is not — and now that production fetches on demand, the index is the only thing standing between a visitor and a download once the mirror is retired.

## Shape

Two retries at 5s and 15s. Long enough for a gateway hiccup to pass, short enough that three attempts cannot overrun the hour between runs. Failing after that still aborts the run, which leaves the previous index untouched rather than replacing it with a worse one.

## Verification

Exercised with a stub, since a real 504 cannot be summoned on demand:

```
releases list failed (RuntimeError: 504 - Gateway Time-out), retrying in 5s
releases list failed (RuntimeError: 504 - Gateway Time-out), retrying in 15s
two failures then success -> [:ok] after 3 attempts

always failing -> gave up after 3 attempts, raised RuntimeError
```

Then `--dry-run` against the real API on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VLv5dEVzJeT2LLzBSzZKn