### PR TITLE
Offer only the editions upstream actually builds

### DIFF
--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -64,7 +64,13 @@ module Cameras
       @camera.network_interface = params[:net] if params[:net]
       @camera.sd_card_slot = params[:sd] if params[:sd]
 
-      @camera.soc = Soc.find_by_urlname(params[:id])
+      # Soc.find, like every other action. find_by_urlname answers nil for a
+      # slug that does not exist, and the next line then raises NoMethodError on
+      # nil -- so /cameras/vendors/rockchip/socs/rv1106, a SoC this site has no
+      # row for, is a 500 rather than a 404. That is the exact failure Soc.find
+      # was overridden to prevent, and this action was the one place still
+      # bypassing it. RescueHandler turns RecordNotFound into the 404 page.
+      @camera.soc = Soc.find(params[:id])
       @vendor = @camera.soc.vendor
 
       @page_title = "SoC: #{@camera.soc.full_name}"

--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -73,6 +73,12 @@ module Cameras
       @camera.soc = Soc.find(params[:id])
       @vendor = @camera.soc.vendor
 
+      # nor8m is the default for almost every SoC and wrong for the ones
+      # upstream builds only a NAND image for -- rv1109 and rv1126 here today.
+      # Their NOR sizes are disabled in the menu, so the form opened on a
+      # disabled flash type with no edition to go with it.
+      @camera.flash_type = @camera.soc.default_flash_chip if params[:rom].blank?
+
       @page_title = "SoC: #{@camera.soc.full_name}"
       render 'cameras/socs/show'
     end
@@ -101,6 +107,12 @@ module Cameras
       @camera.soc = Soc.find(params[:id])
       @vendor = @camera.soc.vendor
 
+      # nor8m is the default for almost every SoC and wrong for the ones
+      # upstream builds only a NAND image for -- rv1109 and rv1126 here today.
+      # Their NOR sizes are disabled in the menu, so the form opened on a
+      # disabled flash type with no edition to go with it.
+      @camera.flash_type = @camera.soc.default_flash_chip if params[:rom].blank?
+
       if @vendor.name.eql?("SigmaStar") && @camera.flash_type.eql?("nand")
         render 'cameras/socs/sigmastar_nand_is_weird'
       elsif @camera.soc.model.in?(%w[HI3536CV100 HI3536DV100])
@@ -115,6 +127,13 @@ module Cameras
            @camera.soc.available_releases('nor').include?('lite')
           @camera.firmware_version = 'lite'
           flash.now[:warning] = '8MB Flash ROM can only be flashed with Lite or FPV edition!'
+        end
+
+        # Everything above this point can be set from the query string.
+        if (asked = @camera.use_published_release!)
+          flash.now[:warning] =
+            "OpenIPC does not publish a #{asked.to_s.capitalize} build for this SoC on " \
+            "#{@camera.flash_type_type.upcase} flash. Showing #{@camera.firmware_version_name} instead."
         end
 
         @camera.backup_filename = "backup-#{@camera.soc.model.downcase}-#{@camera.flash_type}.bin"

--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -100,7 +100,13 @@ module Cameras
       elsif @camera.soc.model.in?(%w[HI3536CV100 HI3536DV100])
         render 'cameras/socs/hi3536dv100_is_weird'
       else
-        if @camera.flash_type.eql?('nor8m') && @camera.firmware_version.eql?('ultimate')
+        # Only when there is a Lite build to fall back to. hi3516cv6xx and
+        # hi3519dv500 are published as Ultimate and nothing else, so downgrading
+        # unconditionally would answer with instructions for a tarball that does
+        # not exist -- swapping a size problem the visitor can see for a missing
+        # file they cannot.
+        if @camera.flash_type.eql?('nor8m') && @camera.firmware_version.eql?('ultimate') &&
+           @camera.soc.available_releases('nor').include?('lite')
           @camera.firmware_version = 'lite'
           flash.now[:warning] = '8MB Flash ROM can only be flashed with Lite or FPV edition!'
         end

--- a/app/helpers/selects_helper.rb
+++ b/app/helpers/selects_helper.rb
@@ -7,17 +7,36 @@ module SelectsHelper
     end
   end
 
+  # NAND is offered for every SoC today, and upstream builds a NAND image for
+  # sixteen boards. Choosing it anywhere else produced instructions for a
+  # tarball that does not exist. A flash type upstream builds nothing for is
+  # disabled rather than hidden, so the menu still shows what the part has.
   def list_of_flash_type_sizes_for_select
-    Camera::FLASH_CHIP.map do |v|
-      [t("flash_chip.#{v}"), v]
+    availability = @camera.soc.release_availability
+
+    Camera::FLASH_CHIP.map do |chip|
+      flash_type = chip.start_with?('nand') ? 'nand' : 'nor'
+      option = [t("flash_chip.#{chip}"), chip]
+      availability[flash_type].empty? ? option + [{ disabled: true }] : option
     end
   end
 
+  # Every SoC used to be offered lite, ultimate and fabricator whatever upstream
+  # built. The list comes from the release index now -- the union across flash
+  # types, because the flash type is chosen in the same form without a round
+  # trip and the script on the page narrows it from there.
+  #
+  # The line removed here deleted 'venc' from a list that has never contained
+  # it, guarded by a condition naming GK7205210, which is not a SoC. It had no
+  # effect either way.
+  #
+  # The default label matters: `fabricator` has no translation in any locale, so
+  # `t` rendered a translation_missing span inside an <option> on every SoC page
+  # on the site. An edition upstream invents tomorrow gets its own name rather
+  # than that.
   def list_of_firmware_versions_for_select
-    data = Camera::FW_VERSION.dup
-    data.delete('venc') unless @camera.soc.vendor.name.eql?('Goke') && @camera.soc.model.in?(%w[GK7205V200 GK7205210 GK7205V300])
-    data.map do |v|
-      [t("firmware.version.#{v}"), v]
+    @camera.soc.offerable_releases.map do |release|
+      [t("firmware.version.#{release}", default: release.capitalize), release]
     end
   end
 

--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -141,16 +141,48 @@ class Camera
     end
   end
 
-  # What this SoC actually has, when there is one to ask. Unioning with
-  # FW_VERSION here would have made the rule say nothing: ultimate would be
-  # permitted for the 42 SoCs upstream does not build it for, which is the
-  # thing being fixed.
-  def permitted_firmware_versions
-    soc.nil? ? FW_VERSION : soc.offerable_releases
+  # What this SoC has for the flash type actually chosen. The union across flash
+  # types would let a NAND-only edition through for a NOR part and back again:
+  # sixteen boards have a NAND build, eleven of those are Ultimate-only and five
+  # are Lite-only, so the two lists genuinely differ.
+  #
+  # Unioning with FW_VERSION would have made the rule say nothing at all --
+  # Ultimate permitted for the 42 SoCs upstream does not build it for, which is
+  # the thing being fixed.
+  # Move to an edition upstream publishes for the chosen flash type, and answer
+  # what was asked for so the caller can say what it did. nil when nothing
+  # needed changing.
+  #
+  # Nothing calls valid? on a Camera -- these pages are rendered, never saved --
+  # and every field arrives from the request, so without this a hand-edited
+  # query string produces a full page of installation steps for a tarball that
+  # was never built. The same shape as the 8MB downgrade that has always been
+  # here, applied to what exists rather than to what fits.
+  def use_published_release!
+    return nil if soc.nil?
+
+    available = soc.available_releases(flash_type_type)
+    return nil if available.empty? || available.include?(firmware_version)
+
+    asked = firmware_version
+    self.firmware_version = available.first
+    @firmware_version_name = nil
+    asked
   end
 
+  def permitted_firmware_versions
+    return FW_VERSION if soc.nil?
+
+    soc.available_releases(flash_type_type).presence || soc.offerable_releases
+  end
+
+  # The same default as the selector. Without it an edition upstream publishes
+  # that this site has no translation for is picked from the menu by its proper
+  # name and then rendered as a translation_missing span everywhere else on the
+  # installation page.
   def firmware_version_name
-    @firmware_version_name ||= I18n.t("firmware.version.#{firmware_version}")
+    @firmware_version_name ||= I18n.t("firmware.version.#{firmware_version}",
+                                      default: firmware_version.to_s.capitalize)
   end
 
   # The NOR numbers come from FlashLayout, which reads them off the bootloader

--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -4,7 +4,11 @@ class Camera
   include ActiveModel::Model
   include ActiveModel::Validations
 
-  FW_VERSION = %w[lite ultimate fabricator].freeze
+  # What this model will accept, rather than what any particular SoC offers --
+  # Soc#available_releases answers that, and the form is built from it.
+  # `fabricator` is gone: upstream publishes no fabricator build for any SoC and
+  # never has. `neo` is here because it does exist, for seven boards.
+  FW_VERSION = %w[lite ultimate neo].freeze
   FLASH_CHIP = %w[nor8m nor16m nor32m nand].freeze
   NET_IFACE = %w[eth wifi both].freeze
   SD_CARD = %w[nosd sd].freeze
@@ -35,7 +39,11 @@ class Camera
 
   validates :soc_id, presence: true
   validates :flash_type, presence: true
-  validates :firmware_version, inclusion: { in: FW_VERSION }
+  # Against what the SoC actually has when there is one, so a hand-edited form
+  # cannot ask for an edition upstream does not build. FW_VERSION is the answer
+  # when there is no SoC to ask, and when the index cannot be read
+  # available_releases returns the known list, so this never becomes unsatisfiable.
+  validates :firmware_version, inclusion: { in: ->(camera) { camera.permitted_firmware_versions } }
   validates :camera_mac_address, format: { with: MAC_ADDRESS_FORMAT }
   validates :camera_ip_address, format: { with: IP_ADDRESS_FORMAT }
   validates :server_ip_address, format: { with: IP_ADDRESS_FORMAT }
@@ -131,6 +139,14 @@ class Camera
     when 'nand'
       '262144'
     end
+  end
+
+  # What this SoC actually has, when there is one to ask. Unioning with
+  # FW_VERSION here would have made the rule say nothing: ultimate would be
+  # permitted for the 42 SoCs upstream does not build it for, which is the
+  # thing being fixed.
+  def permitted_firmware_versions
+    soc.nil? ? FW_VERSION : soc.offerable_releases
   end
 
   def firmware_version_name

--- a/app/models/release_index.rb
+++ b/app/models/release_index.rb
@@ -97,4 +97,29 @@ class ReleaseIndex
   def size
     @assets.size
   end
+
+  # Which editions upstream publishes for a board and flash type, read out of
+  # the asset names rather than from a list kept here. A variant this site has
+  # never heard of therefore becomes offerable the hour it first appears, which
+  # is how `neo` should have arrived instead of shipping to seven boards that
+  # nothing here could reach.
+  ASSET_NAME = /\Aopenipc\.(.+)-(nor|nand)-([a-z0-9]+)\.tgz\z/
+
+  def releases_for(board, flash_type)
+    builds[[board.to_s, flash_type.to_s]] || []
+  end
+
+  private
+
+  # Built once per index document, which is itself memoised until the file on
+  # disk moves on. One pass over ~200 names.
+  def builds
+    @builds ||= @assets.each_key.with_object({}) do |name, map|
+      match = ASSET_NAME.match(name)
+      next unless match
+
+      (map[[match[1], match[2]]] ||= []) << match[3]
+    end
+  end
+
 end

--- a/app/models/soc.rb
+++ b/app/models/soc.rb
@@ -93,10 +93,21 @@ class Soc < ApplicationRecord
   # Falling back to the known list keeps the old behaviour when the index
   # cannot be read, rather than emptying the menu.
   def available_releases(flash_type)
-    found = ReleaseIndex.current.releases_for(board, flash_type)
-    found.sort_by { |release| [RELEASE_ORDER.index(release) || RELEASE_ORDER.size, release] }
+    published_releases(flash_type)
   rescue ReleaseIndex::Missing
+    # Offer the usual three rather than an empty menu. Some of them may not
+    # exist for this board -- that is the whole problem being fixed -- but a
+    # menu with nothing in it makes every SoC unusable for as long as the index
+    # is unreadable, and the download path answers "could not be fetched right
+    # now" rather than pretending. Anything that would put a bare GitHub URL in
+    # front of a visitor uses published_releases instead, which stays silent.
     RELEASE_ORDER
+  end
+
+  # Strictly what the index says, and nothing when it cannot be read.
+  def published_releases(flash_type)
+    ReleaseIndex.current.releases_for(board, flash_type)
+                .sort_by { |release| [RELEASE_ORDER.index(release) || RELEASE_ORDER.size, release] }
   end
 
   # Every edition offerable for this SoC, across flash types. The menu carries
@@ -112,6 +123,23 @@ class Soc < ApplicationRecord
   # flash type, for this SoC.
   def release_availability
     FLASH_TYPES.to_h { |flash_type| [flash_type, available_releases(flash_type)] }
+  end
+
+  # nor8m suits almost every SoC and is wrong for the ones upstream builds only
+  # a NAND image for -- rv1109 and rv1126 here today. Their NOR sizes are
+  # disabled in the menu, so opening the form on one left it with a flash type
+  # that cannot be chosen and no edition to go with it.
+  def default_flash_chip
+    available_releases('nor').any? ? 'nor8m' : 'nand'
+  end
+
+  # For the links out to GitHub, which have to name a file that is there. An
+  # unreadable index means no links rather than links built on a guess: a 404 on
+  # github.com is off-site, with nothing from this site to explain it.
+  def published_availability
+    FLASH_TYPES.to_h { |flash_type| [flash_type, published_releases(flash_type)] }
+  rescue ReleaseIndex::Missing
+    FLASH_TYPES.to_h { |flash_type| [flash_type, []] }
   end
 
   # A flash image starts with a bootloader, and for twenty-one of the SoCs on

--- a/app/models/soc.rb
+++ b/app/models/soc.rb
@@ -57,10 +57,13 @@ class Soc < ApplicationRecord
     format GH_DL_ROOT, uboot_filename
   end
 
-  def fw_url(version)
-    filename = linux_filename.dup
-    filename.gsub('-br.tgz', "-#{version}-br.tgz") unless version.eql?('lite')
-    format GH_DL_ROOT, filename
+  # Not used by any view today. It returned the lite filename for every version
+  # asked for -- `gsub` without `!` and without assigning the result -- and it
+  # still spoke the pre-2023 `-br.tgz` naming, so it would have answered a dead
+  # URL for whoever reached for it next. Built from the same rule as everything
+  # else now.
+  def fw_url(release, flash_type = 'nor')
+    format GH_DL_ROOT, linux_filename_for(release, flash_type)
   end
 
   def full_name
@@ -71,11 +74,45 @@ class Soc < ApplicationRecord
     !uboot_filename.empty? && !linux_filename.empty?
   end
 
-  # Everything upstream builds, for asking whether it builds anything at all for
-  # a board. Two flash types times three editions is six lookups in a hash that
-  # is already in memory.
-  PUBLISHED_RELEASES = %w[lite ultimate neo].freeze
   FLASH_TYPES = %w[nor nand].freeze
+
+  # Display order for the editions we know about. Not a filter: anything else
+  # upstream publishes is offered too, after these, so a new variant does not
+  # wait on a deploy here. `fabricator` is deliberately absent -- it was offered
+  # for every SoC for years and upstream has never published one.
+  RELEASE_ORDER = %w[lite ultimate neo].freeze
+
+  # The editions upstream actually publishes for this board and flash type.
+  #
+  # The site used to offer lite, ultimate and fabricator for all 126 SoCs
+  # regardless. Ultimate does not exist for 42 of them, fabricator exists for
+  # none, and neo -- which does exist, for seven boards -- could not be reached
+  # at all. Every one of those was a dead download the visitor only discovered
+  # after choosing, submitting and clicking.
+  #
+  # Falling back to the known list keeps the old behaviour when the index
+  # cannot be read, rather than emptying the menu.
+  def available_releases(flash_type)
+    found = ReleaseIndex.current.releases_for(board, flash_type)
+    found.sort_by { |release| [RELEASE_ORDER.index(release) || RELEASE_ORDER.size, release] }
+  rescue ReleaseIndex::Missing
+    RELEASE_ORDER
+  end
+
+  # Every edition offerable for this SoC, across flash types. The menu carries
+  # the union because the flash type is chosen in the same form, without a
+  # round trip, and the script narrows it from there.
+  def offerable_releases
+    FLASH_TYPES.flat_map { |flash_type| available_releases(flash_type) }
+               .uniq
+               .sort_by { |release| [RELEASE_ORDER.index(release) || RELEASE_ORDER.size, release] }
+  end
+
+  # What the flash-type menu and the script need: which editions go with which
+  # flash type, for this SoC.
+  def release_availability
+    FLASH_TYPES.to_h { |flash_type| [flash_type, available_releases(flash_type)] }
+  end
 
   # A flash image starts with a bootloader, and for twenty-one of the SoCs on
   # this site there is not one. Every Xiongmai part is like this, and the whole
@@ -98,10 +135,13 @@ class Soc < ApplicationRecord
     true
   end
 
+  # Asked against the index directly rather than through available_releases,
+  # which answers optimistically when there is no index. Optimism is right for
+  # a menu -- offer the usual editions rather than an empty one -- and wrong
+  # here, where the answer decides whether to tell somebody firmware exists.
   def firmware_published?
-    PUBLISHED_RELEASES.any? do |release|
-      FLASH_TYPES.any? { |flash_type| ReleaseIndex.current.fetch(linux_filename_for(release, flash_type)) }
-    end
+    index = ReleaseIndex.current
+    FLASH_TYPES.any? { |flash_type| index.releases_for(board, flash_type).any? }
   rescue ReleaseIndex::Missing
     linux_filename.present?
   end

--- a/app/views/cameras/socs/show.html.erb
+++ b/app/views/cameras/socs/show.html.erb
@@ -120,7 +120,17 @@
     function allowedEditions(chip) {
         const published = availability[chip.startsWith('nand') ? 'nand' : 'nor'] || [];
         const limit = sizeLimits[chip];
-        return limit ? published.filter(v => limit.includes(v)) : published;
+        if (!limit) return published;
+
+        // The size rule narrows what exists; it must not empty the menu. No SoC
+        // listed today can hit this -- every board with a NOR build has a Lite
+        // one -- but hi3516cv6xx and hi3519dv500 are built only as Ultimate, so
+        // the first of those to be added here would otherwise offer nothing at
+        // all on 8M and 16M. Offering what exists and letting the server answer
+        // PayloadTooLarge, which it does with its own message, beats a menu with
+        // every entry greyed out and no explanation.
+        const fits = published.filter(v => limit.includes(v));
+        return fits.length ? fits : published;
     }
 
     function checkFlashSize() {

--- a/app/views/cameras/socs/show.html.erb
+++ b/app/views/cameras/socs/show.html.erb
@@ -15,7 +15,7 @@
   </header>
 
   <div class="row">
-    <% if @camera.soc.uboot_filename.blank? || @camera.soc.linux_filename.blank? || @camera.soc.load_address.blank? %>
+    <% if @camera.soc.uboot_filename.blank? || @camera.soc.linux_filename.blank? || @camera.soc.load_address.blank? || !@camera.soc.firmware_published? %>
       <div class="col-md-6 col-xl-7 col-xxl-8 mb-3">
         <div class="alert alert-info">
           <%# Firmware published but no bootloader is a different thing from not %>
@@ -37,12 +37,22 @@
             <p class="mb-0 small"><%= t('.for', name: @camera.soc.full_name) %></p>
           </div>
         <% end %>
-        <% unless @camera.soc.linux_filename.blank? %>
-          <div class="alert alert-primary github">
-            <i class="bi bi-github float-end"></i>
-            <h5 class="mb-1"><%= link_to t('.bundle', name: @camera.firmware_version_name), firmware_url(@camera), title: firmware_filename(@camera) %></h5>
-            <p class="mb-0 small"><%= t('.for', name: @camera.soc.full_name) %></p>
-          </div>
+        <%# One link per edition upstream actually publishes. This used to be a %>
+        <%# single link built by string template from whatever the form had     %>
+        <%# selected, with no existence check at all -- a bare 404 on github.com %>
+        <%# for the visitor, off-site, with no message from this site to explain %>
+        <%# it. Arguably worse than the failed download, since they cannot tell  %>
+        <%# whether we are broken or their camera is unsupported.                %>
+        <% @camera.soc.release_availability.each do |flash_type, releases| %>
+          <% releases.each do |release| %>
+            <div class="alert alert-primary github">
+              <i class="bi bi-github float-end"></i>
+              <h5 class="mb-1"><%= link_to t('.bundle', name: "#{t("firmware.version.#{release}", default: release.capitalize)} #{flash_type.upcase}"),
+                                           @camera.soc.fw_url(release, flash_type),
+                                           title: @camera.soc.linux_filename_for(release, flash_type) %></h5>
+              <p class="mb-0 small"><%= t('.for', name: @camera.soc.full_name) %></p>
+            </div>
+          <% end %>
         <% end %>
       </div>
     <% else %>
@@ -71,7 +81,8 @@
             </div>
             <div class="col">
               <%= f.select :flash_type, list_of_flash_type_sizes_for_select %>
-              <%= f.select :firmware_version, list_of_firmware_versions_for_select %>
+              <%= f.select :firmware_version, list_of_firmware_versions_for_select,
+                           {}, data: { availability: @camera.soc.release_availability.to_json } %>
               <!-- %= f.select :network_interface, list_of_network_interfaces_for_select % -->
               <!-- %= f.select :sd_card_slot, list_of_sd_card_for_select % -->
             </div>
@@ -89,38 +100,41 @@
 </article>
 
 <script>
-    function checkFlashSize() {
-        let el = document.querySelector('#camera_firmware_version');
+    // Which editions go with which flash type, for this SoC, straight from the
+    // release index. What this replaces was a fixed table: nand meant ultimate,
+    // nor8m and nor16m meant lite, and nor32m meant everything-but-fabricator,
+    // for all 126 SoCs alike. Upstream builds nand for sixteen boards and five
+    // of those are lite-only, so the nand rule was wrong in both directions.
+    const availability = JSON.parse(
+        document.querySelector('#camera_firmware_version').dataset.availability
+    );
 
-        if (document.querySelector('#camera_flash_type').value === 'nor8m') {
-            for (let i = 0; i < el.options.length; i++) {
-                let o = el.options.item(i);
-                o.disabled = (o.value !== 'lite');
-            }
-            el.value = 'lite';
-        } else if (document.querySelector('#camera_flash_type').value === 'nor16m') {
-            for (let i = 0; i < el.options.length; i++) {
-                let o = el.options.item(i);
-                o.disabled = (o.value !== 'lite');
-            }
-            el.value = 'lite';
-        } else if (document.querySelector('#camera_flash_type').value === 'nor32m') {
-            for (let i = 0; i < el.options.length; i++) {
-                let o = el.options.item(i);
-                o.disabled = (o.value == 'fabricator'<%= raw " || o.value == 'fpv'" unless @camera.soc.vendor.name.eql?('SigmaStar') %>);
-            }
-            el.value = 'ultimate';
-        } else if (document.querySelector('#camera_flash_type').value === 'nand') {
-            for (let i = 0; i < el.options.length; i++) {
-                let o = el.options.item(i);
-                o.disabled = (o.value !== 'ultimate');
-            }
-            el.value = 'ultimate';
-        } else {
-            for (let i = 0; i < el.options.length; i++) {
-                let o = el.options.item(i);
-                o.disabled = (o.value == 'fpv');
-            }
+    // Flash size still constrains the edition independently of what exists:
+    // an 8MB part cannot hold Ultimate whether or not it is published. Kept
+    // exactly as it was.
+    const sizeLimits = {nor8m: ['lite'], nor16m: ['lite']};
+
+    // What to land on when the current choice is no longer available.
+    const preferred = {nor32m: 'ultimate', nand: 'ultimate'};
+
+    function allowedEditions(chip) {
+        const published = availability[chip.startsWith('nand') ? 'nand' : 'nor'] || [];
+        const limit = sizeLimits[chip];
+        return limit ? published.filter(v => limit.includes(v)) : published;
+    }
+
+    function checkFlashSize() {
+        const el = document.querySelector('#camera_firmware_version');
+        const chip = document.querySelector('#camera_flash_type').value;
+        const allowed = allowedEditions(chip);
+
+        for (let i = 0; i < el.options.length; i++) {
+            const o = el.options.item(i);
+            o.disabled = !allowed.includes(o.value);
+        }
+
+        if (!allowed.includes(el.value)) {
+            el.value = allowed.includes(preferred[chip]) ? preferred[chip] : (allowed[0] || '');
         }
     }
 

--- a/app/views/cameras/socs/show.html.erb
+++ b/app/views/cameras/socs/show.html.erb
@@ -43,7 +43,7 @@
         <%# for the visitor, off-site, with no message from this site to explain %>
         <%# it. Arguably worse than the failed download, since they cannot tell  %>
         <%# whether we are broken or their camera is unsupported.                %>
-        <% @camera.soc.release_availability.each do |flash_type, releases| %>
+        <% @camera.soc.published_availability.each do |flash_type, releases| %>
           <% releases.each do |release| %>
             <div class="alert alert-primary github">
               <i class="bi bi-github float-end"></i>
@@ -133,7 +133,21 @@
         return fits.length ? fits : published;
     }
 
+    // A flash type upstream builds nothing for is disabled in its own menu, so
+    // landing on one -- from ?rom= in a shared link, or a stale bookmark --
+    // would leave the edition list empty with nothing to say why. Move to the
+    // first type that is offered instead.
+    function useAnOfferedFlashType() {
+        const chips = document.querySelector('#camera_flash_type');
+        const chosen = chips.options[chips.selectedIndex];
+        if (!chosen || !chosen.disabled) return;
+
+        const usable = Array.from(chips.options).find(o => !o.disabled);
+        if (usable) chips.value = usable.value;
+    }
+
     function checkFlashSize() {
+        useAnOfferedFlashType();
         const el = document.querySelector('#camera_firmware_version');
         const chip = document.querySelector('#camera_flash_type').value;
         const allowed = allowedEditions(chip);

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -107,6 +107,7 @@ de:
       fpv: FPV
       lite: Lite
       nand: NAND
+      neo: Neo
       ultimate: Ultimate
       venc: VENC
   flash_chip:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,7 @@ en:
       fpv: FPV
       lite: Lite
       nand: NAND
+      neo: Neo
       ultimate: Ultimate
       venc: VENC
   flash_chip:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -107,6 +107,7 @@ es:
       fpv: FPV
       lite: Lite
       nand: Nand
+      neo: Neo
       ultimate: Ultimate
       venc: VENC
   flash_chip:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -107,6 +107,7 @@ fa:
       fpv: FPV
       lite: ساده
       nand: NAND
+      neo: Neo
       ultimate: نهایی
       venc: VENC
   flash_chip:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -107,6 +107,7 @@ fr:
       fpv: FPV
       lite: léger
       nand: NON-ET
+      neo: Neo
       ultimate: Ultime
       venc: VENC
   flash_chip:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -107,6 +107,7 @@ it:
       fpv: FPV
       lite: Lite
       nand: NAND
+      neo: Neo
       ultimate: Ultimate
       venc: VENC
   flash_chip:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -107,6 +107,7 @@ pl:
       fpv: FPV
       lite: Lite
       nand: NAND
+      neo: Neo
       ultimate: Ostateczny
       venc: VENC
   flash_chip:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -107,6 +107,7 @@ pt:
       fpv: FPV
       lite: Leve
       nand: NAND
+      neo: Neo
       ultimate: Final
       venc: VENC
   flash_chip:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -107,6 +107,7 @@ ru:
       fpv: FPV
       lite: Lite
       nand: NAND
+      neo: Neo
       ultimate: Ultimate
       venc: VENC
   flash_chip:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -107,6 +107,7 @@ zh:
       fpv: FPV
       lite: Lite
       nand: Nand
+      neo: Neo
       ultimate: Ultimate
       venc: VENC
   flash_chip:

--- a/test/controllers/socs_controller_test.rb
+++ b/test/controllers/socs_controller_test.rb
@@ -143,4 +143,13 @@ class SocsControllerTest < ActionDispatch::IntegrationTest
     ReleaseIndex.reset!
     FileUtils.remove_entry(root) if root
   end
+
+  test 'an unknown SoC slug on the show page is not found rather than a server error' do
+    # /cameras/vendors/rockchip/socs/rv1106 answered 500 in production: RV1106
+    # has no row here, show used the nil-returning finder, and the next line
+    # called .vendor on nil.
+    assert_raises(ActiveRecord::RecordNotFound) do
+      get "/cameras/vendors/#{@vendor.to_param}/socs/no-such-soc"
+    end
+  end
 end

--- a/test/models/camera_test.rb
+++ b/test/models/camera_test.rb
@@ -140,4 +140,66 @@ class CameraTest < ActiveSupport::TestCase
       end
     end
   end
+
+  # --- editions that are not published ---
+
+  test 'an edition upstream does not build is replaced, and says what was asked for' do
+    vendor = Vendor.create!(name: 'Testco2')
+    soc = Soc.create!(vendor: vendor, model: 'TS377D',
+                      linux_filename: 'openipc.ts377d-nor-lite.tgz')
+    camera = Camera.new(soc: soc, flash_type: 'nor16m', firmware_version: 'ultimate')
+
+    with_index(['openipc.ts377d-nor-lite.tgz']) do
+      assert_equal 'ultimate', camera.use_published_release!
+      assert_equal 'lite', camera.firmware_version
+      assert_equal 'Lite', camera.firmware_version_name
+    end
+  end
+
+  test 'an edition that is published is left alone' do
+    vendor = Vendor.create!(name: 'Testco3')
+    soc = Soc.create!(vendor: vendor, model: 'TS338Q',
+                      linux_filename: 'openipc.ts338q-nor-lite.tgz')
+    camera = Camera.new(soc: soc, flash_type: 'nor32m', firmware_version: 'ultimate')
+
+    with_index(['openipc.ts338q-nor-lite.tgz', 'openipc.ts338q-nor-ultimate.tgz']) do
+      assert_nil camera.use_published_release!
+      assert_equal 'ultimate', camera.firmware_version
+    end
+  end
+
+  test 'the flash type decides which list is consulted' do
+    vendor = Vendor.create!(name: 'Testco4')
+    soc = Soc.create!(vendor: vendor, model: 'TS1109',
+                      linux_filename: 'openipc.ts1109-nand-lite.tgz')
+
+    with_index(['openipc.ts1109-nand-lite.tgz', 'openipc.ts1109-nor-ultimate.tgz']) do
+      nand = Camera.new(soc: soc, flash_type: 'nand', firmware_version: 'ultimate')
+      assert_equal 'ultimate', nand.use_published_release!
+      assert_equal 'lite', nand.firmware_version
+
+      nor = Camera.new(soc: soc, flash_type: 'nor32m', firmware_version: 'ultimate')
+      assert_nil nor.use_published_release!
+    end
+  end
+
+  test 'an edition with no translation is labelled by its own name' do
+    camera = Camera.new(firmware_version: 'zephyr')
+
+    assert_equal 'Zephyr', camera.firmware_version_name
+  end
+
+  def with_index(assets)
+    root = Dir.mktmpdir
+    ENV['RELEASE_INDEX_ROOT'] = root
+    File.write(File.join(root, '.index.json'),
+               JSON.generate('generated_at' => '2026-08-24T00:00:00Z', 'aliases' => {},
+                             'assets' => assets.to_h { |n| [n, { 'size' => 1 }] }))
+    ReleaseIndex.reset!
+    yield
+  ensure
+    ENV.delete('RELEASE_INDEX_ROOT')
+    ReleaseIndex.reset!
+    FileUtils.remove_entry(root) if root
+  end
 end

--- a/test/models/soc_test.rb
+++ b/test/models/soc_test.rb
@@ -336,4 +336,27 @@ class SocTest < ActiveSupport::TestCase
     assert_match(/openipc\.ts3516ev304-nor-ultimate\.tgz\z/, soc.fw_url('ultimate'))
     assert_match(/openipc\.ts3516ev304-nand-lite\.tgz\z/, soc.fw_url('lite', 'nand'))
   end
+
+  test 'the GitHub links stay silent when the index cannot be read' do
+    # available_releases guesses so the menu is not empty; these become bare
+    # URLs on github.com, so they must not be guesses.
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516EV305',
+                      linux_filename: 'openipc.ts3516ev305-nor-lite.tgz')
+
+    ReleaseIndex.reset!
+    assert_equal({ 'nor' => [], 'nand' => [] }, soc.published_availability)
+    assert_equal Soc::RELEASE_ORDER, soc.available_releases('nor')
+  end
+
+  test 'the wizard opens on a flash type the SoC actually has' do
+    nand_only = Soc.create!(vendor: @vendor, model: 'TS1109',
+                            linux_filename: 'openipc.ts1109-nand-lite.tgz')
+    ordinary = Soc.create!(vendor: @vendor, model: 'TS338Q',
+                           linux_filename: 'openipc.ts338q-nor-lite.tgz')
+
+    with_index(assets: ['openipc.ts1109-nand-lite.tgz', 'openipc.ts338q-nor-lite.tgz']) do
+      assert_equal 'nand', nand_only.default_flash_chip
+      assert_equal 'nor8m', ordinary.default_flash_chip
+    end
+  end
 end

--- a/test/models/soc_test.rb
+++ b/test/models/soc_test.rb
@@ -254,4 +254,86 @@ class SocTest < ActiveSupport::TestCase
     ReleaseIndex.reset!
     assert_not_predicate soc, :bootloader_published?
   end
+
+  # --- which editions are offered ---
+
+  test 'only the editions upstream publishes are offered' do
+    # Ultimate does not exist for 42 of the SoCs this site lists and fabricator
+    # exists for none of them, yet all three were offered for every SoC.
+    soc = Soc.create!(vendor: @vendor, model: 'TS377D',
+                      linux_filename: 'openipc.ts377d-nor-lite.tgz')
+
+    with_index(assets: ['openipc.ts377d-nor-lite.tgz']) do
+      assert_equal %w[lite], soc.available_releases('nor')
+      assert_empty soc.available_releases('nand')
+      assert_equal %w[lite], soc.offerable_releases
+    end
+  end
+
+  test 'an edition the site has never heard of is offered anyway' do
+    # neo shipped for seven boards and nothing here could reach it, because the
+    # list was a constant. Reading the names means the next one does not wait
+    # on a deploy.
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516EV301',
+                      linux_filename: 'openipc.ts3516ev301-nor-lite.tgz')
+
+    with_index(assets: ['openipc.ts3516ev301-nor-lite.tgz',
+                        'openipc.ts3516ev301-nor-neo.tgz',
+                        'openipc.ts3516ev301-nor-zephyr.tgz']) do
+      assert_equal %w[lite neo zephyr], soc.offerable_releases
+    end
+  end
+
+  test 'editions are ordered lite, ultimate, neo, then whatever else' do
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516EV302',
+                      linux_filename: 'openipc.ts3516ev302-nor-lite.tgz')
+
+    with_index(assets: ['openipc.ts3516ev302-nor-neo.tgz',
+                        'openipc.ts3516ev302-nor-lite.tgz',
+                        'openipc.ts3516ev302-nor-ultimate.tgz']) do
+      assert_equal %w[lite ultimate neo], soc.available_releases('nor')
+    end
+  end
+
+  test 'nand and nor are answered separately' do
+    # Five NAND boards are lite-only while the page forced Ultimate for NAND,
+    # and most SoCs have no NAND build at all.
+    soc = Soc.create!(vendor: @vendor, model: 'TS1106',
+                      linux_filename: 'openipc.ts1106-nand-lite.tgz')
+
+    with_index(assets: ['openipc.ts1106-nand-lite.tgz']) do
+      assert_empty soc.available_releases('nor')
+      assert_equal %w[lite], soc.available_releases('nand')
+      assert_equal({ 'nor' => [], 'nand' => %w[lite] }, soc.release_availability)
+    end
+  end
+
+  test 'the alias decides which board the editions are read from' do
+    soc = Soc.create!(vendor: @vendor, model: 'TS7205V210',
+                      linux_filename: 'openipc.ts7205v210-nor-lite.tgz')
+
+    with_index(aliases: { 'ts7205v210' => 'ts7205v200' },
+               assets: ['openipc.ts7205v200-nor-lite.tgz',
+                        'openipc.ts7205v200-nor-ultimate.tgz']) do
+      assert_equal %w[lite ultimate], soc.offerable_releases
+    end
+  end
+
+  test 'no index offers the editions it always used to' do
+    # An empty menu would be worse than the problem being fixed.
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516EV303',
+                      linux_filename: 'openipc.ts3516ev303-nor-lite.tgz')
+
+    ReleaseIndex.reset!
+    assert_equal Soc::RELEASE_ORDER, soc.available_releases('nor')
+  end
+
+  test 'fw_url names the release it was asked for' do
+    # It returned the lite filename for every version, in the pre-2023 naming.
+    soc = Soc.create!(vendor: @vendor, model: 'TS3516EV304',
+                      linux_filename: 'openipc.ts3516ev304-nor-lite.tgz')
+
+    assert_match(/openipc\.ts3516ev304-nor-ultimate\.tgz\z/, soc.fw_url('ultimate'))
+    assert_match(/openipc\.ts3516ev304-nand-lite\.tgz\z/, soc.fw_url('lite', 'nand'))
+  end
 end


### PR DESCRIPTION
Closes #53.

Every SoC page offered Lite, Ultimate and Fabricator from a constant, with no check that any of them existed. Against the current release index:

| edition | offered for | actually published for |
|---|---:|---:|
| lite | all 126 | 70 boards |
| ultimate | all 126 | 37 boards — **dead for 42 of the listed SoCs** |
| fabricator | all 126 | **0, ever** |
| neo | never | 7 boards — **unreachable** |

Fabricator was worse than a dead option: it has no translation in any locale, so `t` rendered a `translation_missing` **span inside an `<option>`** on every SoC page on the site, in every language.

## Measured effect, on dev against the live index

```
wizard form rendered: 57 before -> 56 after
SoCs that lose the form (upstream publishes nothing): 1   (MSC313E)

of the 56 that keep it:
  offered a dead edition before:            56
  gain an edition they could not reach:      7
  NAND now disabled (no nand build):        46
```

That last line is the one the issue did not anticipate: 46 of 56 SoCs offered a NAND installation for a board upstream builds no NAND image for. The script forced `ultimate` whenever NAND was selected — and five of the sixteen boards that *do* have NAND builds are Lite-only, so the rule was wrong in both directions.

SSC377D, the SoC from OpenIPC/firmware#2215:

```
data-availability="{"nor":["lite"],"nand":[]}"
  <option selected value="lite">Lite</option>          <- and nothing else
flash type menu: nor8m, nor16m, nor32m, [nand DISABLED]
```

## The change

- `ReleaseIndex#releases_for(board, flash_type)` reads editions out of the asset names, so a variant upstream invents becomes offerable the hour it appears rather than waiting on a deploy. Ordering is lite, ultimate, neo, then anything else; an unknown edition gets its own capitalised name rather than markup.
- `Soc#available_releases` / `#offerable_releases` / `#release_availability`, all resolving through the alias map from #97 — so GK7205V210 reads GK7205V200's editions.
- The script reads a `data-availability` attribute instead of its fixed table. **Flash-size limits are unchanged** and still applied on top: an 8MB part cannot hold Ultimate whether or not it is published.
- A flash type upstream builds nothing for is disabled in its own menu.
- The bundle link in the not-ready panel is one link per edition that exists. It was a string template with no existence check — for a missing edition, a bare 404 on github.com, off-site, with nothing from this site to explain it.
- The wizard is not rendered at all when upstream publishes nothing for the SoC; that page shows the message from #98 instead of a form that can only fail.

Also from the issue: the helper deleted `'venc'` from a list that never contained it, guarded by a condition naming `GK7205210` — not a SoC; and `Soc#fw_url` discarded its own `gsub`, returning the Lite filename for every version, in the pre-2023 naming that would 404.

## Verification

132 tests pass, 15 new. The script has no test harness here, so I extracted its logic from the rendered page and ran it under node against every availability shape upstream actually has — which is how the empty-menu case below was found.

```
ssc377d      (nor lite only)      nor8m=[lite]  nor16m=[lite]  nor32m=[lite]  nand=[]
hi3516ev300  (nor+neo, nand ult)  nor8m=[lite]  nor16m=[lite]  nor32m=[lite,ultimate,neo]  nand=[ultimate]
rv1106       (nand lite only)     nor8m=[]  nor16m=[]  nor32m=[]  nand=[lite]
hi3516cv6xx  (nor ultimate only)  nor8m=[ultimate]  nor16m=[ultimate]  nor32m=[ultimate]  nand=[]
```

The remaining empty cells are flash types disabled in their own menu, so they cannot be selected.

`hi3516cv6xx` needed the second commit: it is published as Ultimate only, so the below-32M Lite rule emptied its menu entirely. No listed SoC can hit that today, but `hi3516cv6xx` and `hi3519dv500` are precisely the boards the alias map points `hi3516cv610`, `hi3516cv608` and `hi3516dv500` at, so the first of those to be added would have. The same shape also made `update` downgrade Ultimate to Lite on 8MB flash for a board with no Lite build; it now downgrades only when there is one.
