### PR TITLE
Serve an image that is already built when its parts cannot be reached

### DIFF
--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -83,9 +83,34 @@ class Firmware
     @size
   end
 
+  # Build if it needs building, and serve what is already there if the parts
+  # cannot be reached.
+  #
+  # The order used to be fixed: resolve both sources, then ask whether the image
+  # was fresh. Resolving goes through ReleaseIndex, so losing .index.json
+  # refused images that were already built, complete and current on disk --
+  # verified, not theorised: an 8,388,608-byte ssc338q image was refused with
+  # `no release index`. The index is one 44KB file written by an hourly cron,
+  # and every firmware download on the site depended on it being readable.
+  #
+  # Unavailable means the parts cannot be had *right now* -- no index, GitHub
+  # unreachable, bytes that did not match. If a usable image is already on disk,
+  # that is the whole answer to the request, so give it. UnknownAsset is not
+  # caught: it means upstream does not publish this at all, and a leftover image
+  # for a name that has been aliased away is exactly what should not be served.
   def generate
     validate_size!
+    build_if_needed
+  rescue ReleaseCache::Unavailable => e
+    raise unless usable?
 
+    Rails.logger.warn "firmware: serving the cached #{filename}, its parts are unavailable: #{e.message}"
+    nil
+  end
+
+  private
+
+  def build_if_needed
     uboot_file = @soc.uboot_file
     unless File.exist?(uboot_file)
       Rails.logger.warn "firmware: #{uboot_file} not found"
@@ -110,14 +135,17 @@ class Firmware
     end
   end
 
-  private
+  # Present, servable, and the size it claims to be. Everything fresh? asks
+  # except whether it is newer than its parts -- which is the one question that
+  # needs the parts, and therefore the index.
+  def usable?
+    File.exist?(filepath) && web_readable? && right_size?
+  end
 
   # file exists, can be served, is the size it claims to be, and is newer than
   # any of its parts
   def fresh?(uboot_file, linux_file)
-    File.exist?(filepath) &&
-      web_readable? &&
-      right_size? &&
+    usable? &&
       File.mtime(uboot_file) < File.mtime(filepath) &&
       File.mtime(linux_file) < File.mtime(filepath)
   end
@@ -130,7 +158,7 @@ class Firmware
   def web_readable?
     return true if (File.stat(filepath).mode & 0o004).positive?
 
-    Rails.logger.warn "firmware: rebuilding #{filename}, the web server cannot read the cached copy"
+    Rails.logger.warn "firmware: the web server cannot read the cached #{filename}"
     false
   end
 
@@ -147,7 +175,7 @@ class Firmware
     actual = File.size(filepath)
     return true if actual == @size.megabytes
 
-    Rails.logger.warn "firmware: rebuilding #{filename}, cached copy is #{actual} bytes, expected #{@size.megabytes}"
+    Rails.logger.warn "firmware: cached #{filename} is #{actual} bytes, expected #{@size.megabytes}"
     false
   end
 

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -138,8 +138,17 @@ class Firmware
   # Present, servable, and the size it claims to be. Everything fresh? asks
   # except whether it is newer than its parts -- which is the one question that
   # needs the parts, and therefore the index.
+  #
+  # Three separate stats, so the file can go between them: deploy/purge-firmware
+  # -cache.sh deletes images older than fourteen days and nothing coordinates
+  # with it. An ENOENT escaping here would turn a handled "try again shortly"
+  # into a 500, and on the fallback path it would replace an accurate message
+  # with a crash. Gone is simply not usable.
   def usable?
     File.exist?(filepath) && web_readable? && right_size?
+  rescue SystemCallError => e
+    Rails.logger.warn "firmware: cannot examine the cached #{filename}: #{e.class}: #{e.message}"
+    false
   end
 
   # file exists, can be served, is the size it claims to be, and is newer than

--- a/app/models/release_index.rb
+++ b/app/models/release_index.rb
@@ -44,12 +44,49 @@ class ReleaseIndex
       @current = nil if @stamp != stamp
       @stamp = stamp
       @current ||= new(JSON.parse(File.read(path)))
+      warn_if_stale(@current)
+      @current
     rescue JSON::ParserError, SystemCallError, IOError => e
       # Everything from here reaches the caller as "no usable index", which is
       # what ReleaseCache turns into Unavailable. Without the IO arms, a file
       # that vanishes between the exist? and the read -- the mirror renames a
       # new one into place every hour -- escapes as an unhandled error instead.
       raise Missing, "#{path} is unreadable: #{e.class}: #{e.message}"
+    end
+
+    # An index frozen by a cron that stopped running looks exactly like a
+    # current one: every name it lists still resolves, and nothing new ever
+    # appears. `generated_at` has been written into the file all along and
+    # nothing has ever read it.
+    #
+    # Warned about rather than refused. A stale index is still the best
+    # information there is, and every download it can answer still works; what
+    # is wanted is for somebody to notice. Throttled, because this is reached
+    # several times per request.
+    STALE_AFTER = 6.hours
+    WARN_EVERY = 1.hour
+
+    def warn_if_stale(index)
+      raw = index.generated_at
+      return if raw.blank?
+
+      generated = Time.zone.parse(raw.to_s)
+      return warn_once("release index: generated_at #{raw.inspect} is not a timestamp") if generated.nil?
+      return if generated > STALE_AFTER.ago
+
+      warn_once("release index: generated #{generated.utc.iso8601}, " \
+                "#{((Time.current - generated) / 3600).round} hours ago -- " \
+                'is the publisher still running?')
+    rescue ArgumentError, TypeError => e
+      warn_once("release index: generated_at is unreadable: #{e.class}: #{e.message}")
+    end
+
+    def warn_once(message)
+      return if @warned_at && @warned_at > WARN_EVERY.ago
+
+      @warned_at = Time.current
+      Rails.logger.warn message
+      nil
     end
 
     def index_path
@@ -59,6 +96,7 @@ class ReleaseIndex
     def reset!
       @current = nil
       @stamp = nil
+      @warned_at = nil
     end
   end
 

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -571,4 +571,17 @@ class FirmwareTest < ActiveSupport::TestCase
       Firmware.new(size: 8, flash_type: 'nor', release: 'lite', soc: gone).generate
     end
   end
+
+  test 'an image deleted while being examined is not usable, and does not escape as ENOENT' do
+    # purge-firmware-cache.sh deletes images older than fourteen days and
+    # nothing coordinates with it, so the file can go between the exist? and the
+    # stat. Letting that escape would turn "try again shortly" into a 500.
+    good, offline = built_then_unreachable
+    assert_equal 8.megabytes, File.size(good.filepath)
+
+    vanishing = ->(_path) { raise Errno::ENOENT, offline.filepath }
+    File.stub(:stat, vanishing) do
+      assert_raises(ReleaseCache::Unavailable) { offline.generate }
+    end
+  end
 end

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -493,4 +493,82 @@ class FirmwareTest < ActiveSupport::TestCase
                    "#{vendor}: the image does not match the page"
     end
   end
+
+  # --- the index going away must not refuse an image that is already built ---
+
+  # Stands in for a Soc whose parts cannot be reached: no index, GitHub
+  # unreachable, bytes that did not match. ReleaseCache raises Unavailable for
+  # all three and Soc passes it straight through.
+  class UnreachableSoc < StubSoc
+    def uboot_file
+      raise ReleaseCache::Unavailable, 'no release index: /srv/github-releases/.index.json is not there'
+    end
+  end
+
+  # The same SoC, with its parts out of reach.
+  def unreachable
+    UnreachableSoc.new(model: 'ts3516ev300', vendor: 'HiSilicon', uboot_file: nil, linux_file: nil)
+  end
+
+  # A built, complete 8MB NOR image, and a Firmware pointing at it whose parts
+  # cannot be reached.
+  def built_then_unreachable
+    good = build(model: 'ts3516ev300', vendor: 'HiSilicon', flash_type: 'nor', size: 8,
+                 release: 'lite',
+                 members: { 'uImage.ts3516ev300' => KERNEL, 'rootfs.squashfs.ts3516ev300' => SQUASHFS })
+    good.generate
+    [good, Firmware.new(size: 8, flash_type: 'nor', release: 'lite', soc: unreachable)]
+  end
+
+  test 'an image already built is served when its parts cannot be reached' do
+    # Verified on dev before this changed: a complete, current 8MB image was
+    # refused with "no release index" because generate resolved both sources
+    # before asking whether it needed them.
+    good, offline = built_then_unreachable
+    assert_equal 8.megabytes, File.size(good.filepath)
+
+    assert_nil offline.generate
+    assert_equal 8.megabytes, File.size(offline.filepath)
+  end
+
+  test 'nothing built means the failure still reaches the caller' do
+    offline = Firmware.new(size: 8, flash_type: 'nor', release: 'lite',
+                           soc: UnreachableSoc.new(model: 'ts3516ev999', vendor: 'HiSilicon',
+                                                   uboot_file: nil, linux_file: nil))
+
+    assert_raises(ReleaseCache::Unavailable) { offline.generate }
+  end
+
+  test 'an image of the wrong size is not served in place of building one' do
+    # The 9,465,856-byte 8MB image that was live on this host is why right_size?
+    # exists. Unreachable parts must not become a reason to serve it.
+    good, offline = built_then_unreachable
+    IO.binwrite(good.filepath, 'x' * 1024)
+
+    assert_raises(ReleaseCache::Unavailable) { offline.generate }
+  end
+
+  test 'an image the web server cannot read is not served either' do
+    good, offline = built_then_unreachable
+    File.chmod(0o600, good.filepath)
+
+    assert_raises(ReleaseCache::Unavailable) { offline.generate }
+  end
+
+  test 'an asset upstream does not publish is still refused, cached image or not' do
+    # UnknownAsset is permanent, not a bad minute. A leftover image for a name
+    # that has since been aliased away is exactly what must not be served.
+    good, = built_then_unreachable
+    assert_equal 8.megabytes, File.size(good.filepath)
+
+    gone = Class.new(StubSoc) do
+      def uboot_file
+        raise ReleaseCache::UnknownAsset, '"openipc.gone-nor-lite.tgz" is not in the release index'
+      end
+    end.new(model: 'ts3516ev300', vendor: 'HiSilicon', uboot_file: nil, linux_file: nil)
+
+    assert_raises(ReleaseCache::UnknownAsset) do
+      Firmware.new(size: 8, flash_type: 'nor', release: 'lite', soc: gone).generate
+    end
+  end
 end

--- a/test/models/release_index_test.rb
+++ b/test/models/release_index_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The index is one file written by an hourly cron, and every firmware download
+# on the site is answered from it.
+class ReleaseIndexTest < ActiveSupport::TestCase
+  def setup
+    @root = Dir.mktmpdir
+    ENV['RELEASE_INDEX_ROOT'] = @root
+    ReleaseIndex.reset!
+  end
+
+  def teardown
+    ENV.delete('RELEASE_INDEX_ROOT')
+    ReleaseIndex.reset!
+    FileUtils.remove_entry(@root)
+  end
+
+  def write(generated_at:, assets: {})
+    File.write(File.join(@root, '.index.json'),
+               JSON.generate('generated_at' => generated_at, 'aliases' => {}, 'assets' => assets))
+    ReleaseIndex.reset!
+  end
+
+  def logged
+    io = StringIO.new
+    previous = Rails.logger
+    Rails.logger = ActiveSupport::Logger.new(io)
+    yield
+    io.string
+  ensure
+    Rails.logger = previous
+  end
+
+  test 'an index frozen by a cron that stopped running is complained about' do
+    # It looks exactly like a current one otherwise: every name it lists still
+    # resolves, and nothing new ever appears.
+    write(generated_at: 30.hours.ago.utc.iso8601)
+
+    assert_match(/is the publisher still running/, logged { ReleaseIndex.current })
+  end
+
+  test 'a current index says nothing' do
+    write(generated_at: 20.minutes.ago.utc.iso8601)
+
+    assert_no_match(/publisher/, logged { ReleaseIndex.current })
+  end
+
+  test 'the complaint is throttled rather than repeated every request' do
+    write(generated_at: 30.hours.ago.utc.iso8601)
+
+    output = logged { 5.times { ReleaseIndex.current } }
+    assert_equal 1, output.scan(/is the publisher still running/).size
+  end
+
+  test 'an unreadable generated_at is reported, not raised' do
+    write(generated_at: 'the day before yesterday')
+
+    assert_match(/is not a timestamp/, logged { ReleaseIndex.current })
+  end
+
+  test 'a missing generated_at is simply not checked' do
+    File.write(File.join(@root, '.index.json'), JSON.generate('assets' => {}))
+    ReleaseIndex.reset!
+
+    assert_no_match(/publisher|timestamp/, logged { ReleaseIndex.current })
+  end
+end


### PR DESCRIPTION
Closes #95.

`Firmware#generate` resolved both source assets **before** asking whether it needed them, and resolving goes through `ReleaseIndex`. So losing one 44 KB file refused downloads whose `.bin` was already complete, current and sitting on disk.

```
built: exists=true 8388608 bytes
WITHOUT INDEX: ReleaseCache::Unavailable: no release index: /tmp/gone/.index.json is not there
```

That is measured on dev, not reasoned about — it is what the issue was filed from.

```ruby
uboot_file = @soc.uboot_file                        # :89  -> ReleaseIndex
linux_file = @soc.linux_file(@release, @flash_type) # :95  -> ReleaseIndex
return if fresh?(uboot_file, linux_file)            # :101
```

## The change

The order is inverted: build, and if the parts cannot be reached, fall back to what is already there.

`Unavailable` means *right now* — no index, GitHub unreachable, bytes that did not match what was promised. If a usable image exists, that is the whole answer to the request.

**Usable** is what `fresh?` already tested, minus the one question that needs the sources: it exists, the web server can read it, and it is the size it claims to be. The 9,465,856-byte "8MB" image that was live on this host is why the size check is not optional, and there is a test that an unreachable index does not become a reason to serve one like it.

**`UnknownAsset` is deliberately not caught.** It means upstream does not publish this at all, which is permanent — and a leftover image for a name that has since been aliased away (`openipc.gk7205v210-*.tgz`, as of this morning) is exactly what must not be served.

**Nothing about the healthy path changes.** With a readable index the mtime comparison runs exactly as before, so an image is still rebuilt the moment either part is newer than it. Five tests pin the fallback's edges; the existing freshness tests pin the rest.

## The other half of the issue

An index frozen by a cron that stopped running looks identical to a current one: every name it lists still resolves, and nothing new ever appears. The only way to notice was a user reporting a SoC that never gains a build. `generated_at` has been written into the file all along and nothing read it.

It is warned about after six hours, throttled to hourly because the index is consulted several times per request — and warned about rather than refused, because a stale index is still the best information there is and every download it can answer still works.

```
release index: generated 2026-08-23T12:05:09Z, 30 hours ago -- is the publisher still running?
```

## Verification

149 tests pass, 10 new — five on the fallback (served when unreachable; still raised when nothing is built; refused for a wrong-sized image; refused for one the web server cannot read; `UnknownAsset` still raised with an image present) and five on staleness, including that the warning is throttled and that an unparseable or absent `generated_at` is reported rather than raised.

I will confirm on dev with the index moved aside before merge — the same experiment that produced the issue, expecting the opposite result.