### PR TITLE
Send endpoint questions to the camera, not to a page we forgot to update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,22 @@ jobs:
           ruby-version: '3.1.7'
           bundler-cache: true
 
+      # app/assets/builds/ is gitignored, so a fresh checkout has no
+      # application.js and sprockets raises "the asset is not present in the
+      # asset pipeline" for any test that renders a page through the layout.
+      # Until this step existed the suite could only test redirects and
+      # exceptions. Node 20 + corepack + `yarn install --immutable` is what the
+      # Dockerfile does, so what builds here builds in the image.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build the assets the layout references
+        run: |
+          corepack enable
+          yarn install --immutable
+          yarn build
+          yarn build:css
+
       # database.yml authenticates as www/www. Grant it globally rather than on
       # one schema: test_helper parallelizes, and each worker creates its own
       # openipc_test-N database.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,6 @@
             <%= dropdown_link t('nav.green_life'), '/green_life' %>
             <%= dropdown_link t('nav.channels'), '/our-channels' %>
             <%= dropdown_link t('nav.webui'), '/web-interface' %>
-            <%= dropdown_link t('nav.endpoints'), '/majestic-endpoints' %>
             <%= dropdown_link t('nav.wiki'), 'https://github.com/openipc/wiki' %>
           </ul>
         </li>

--- a/app/views/pages/majestic_endpoints.html.erb
+++ b/app/views/pages/majestic_endpoints.html.erb
@@ -1,94 +1,28 @@
-<% network_address="192.168.1.10" %>
-
-<article class="majestic endpoins">
+<%# The endpoint list used to live here in full. It fell behind the firmware --
+    the whole /ws/video family, /nwebrtc, config.schema.json and half the night
+    API had shipped without ever reaching this page -- so the list now lives
+    only in the camera's own WebUI, where it is built from the running firmware.
+    The URL stays because search engines, our wiki and other people's forum
+    posts still point at it; it says where the list went instead of 404ing. %>
+<article class="majestic endpoints">
   <header>
     <h2><%= t('.title') %></h2>
   </header>
 
-  <div class="row row-cols-1 row-cols-md-2 g-4 mb-4">
-    <div class="col">
-      <h3><%= t('.video') %></h3>
-      <dl>
-        <dt>http://<%= network_address %>/mjpeg</dt>
-        <dd><%= t('.mjpeg') %></dd>
-        <dt>http://<%= network_address %>/video.mp4</dt>
-        <dd><%= t('.fmp4') %></dd>
-        <dt>rtsp://username:password@<%= network_address %>/stream=0</dt>
-        <dd><%= t('.rtsp0') %></dd>
-        <dt>rtsp://username:password@<%= network_address %>/stream=1</dt>
-        <dd><%= t('.rtsp1') %></dd>
-        <dt>http://<%= network_address %>/hls</dt>
-        <dd><%= t('.hls') %></dd>
-        <dt>http://<%= network_address %>/webrtc</dt>
-        <dd><%= t('.webrtc') %></dd>
-        <dt>http://<%= network_address %>/mjpeg.html</dt>
-        <dd><%= t('.mjpeg_player') %></dd>
-      </dl>
-      <h3><%= t('.audio') %></h3>
-      <dl>
-        <dt>http://<%= network_address %>/audio.opus</dt>
-        <dd><%= t('.opus') %></dd>
-        <dt>http://<%= network_address %>/audio.pcm</dt>
-        <dd><%= t('.raw_pcm') %></dd>
-        <dt>http://<%= network_address %>/audio.m4a</dt>
-        <dd><%= t('.aac') %></dd>
-        <dt class="ult">http://<%= network_address %>/audio.mp3</dt>
-        <dd class="ult"><%= t('.mp3') %></dd>
-        <dt>http://<%= network_address %>/audio.alaw</dt>
-        <dd><%= t('.alaw') %></dd>
-        <dt>http://<%= network_address %>/audio.ulaw</dt>
-        <dd><%= t('.ulaw') %></dd>
-        <dt>http://<%= network_address %>/audio.g711a</dt>
-        <dd><%= t('.g711') %></dd>
-        <dt>http://<%= network_address %>/play_audio</dt>
-        <dd><%= t('.play_on_speaker') %><sup>1,3</sup>
-          <div class="small"><%= t('.accepts_post') %></div></dd>
-      </dl>
-    </div>
-    <div class="col">
-      <h3><%= t('.images') %></h3>
-      <dl>
-        <dt>http://<%= network_address %>/image.jpg</dt>
-        <dd><%= t('.jpeg') %><br><%= t('.optional_params') %>:<sup>2,4</sup>
-          <ul class="small">
-            <li><%= t('.jpeg_params1') %></li>
-            <li><%= t('.jpeg_params2') %></li>
-            <li><%= t('.jpeg_params3') %></li>
-            <li><%= t('.jpeg_params4') %></li>
-          </ul>
-        </dd>
-        <dt>http://<%= network_address %>/image.heif</dt>
-        <dd><%= t('.heif') %></dd>
-        <dt>http://<%= network_address %>/image.yuv420</dt>
-        <dd><%= t('.yuv420') %></dd>
-        <dt>http://<%= network_address %>/image.dng</dt>
-        <dd><%= t('.dng') %><sup>3</sup></dd>
-      </dl>
-      <h3><%= t('.night') %></h3>
-      <dl>
-        <dt>http://<%= network_address %>/night/on</dt>
-        <dd><%= t('.night_on') %></dd>
-        <dt>http://<%= network_address %>/night/off</dt>
-        <dd><%= t('.night_off') %></dd>
-        <dt>http://<%= network_address %>/night/toggle</dt>
-        <dd><%= t('.night_toggle') %></dd>
-      </dl>
-      <h3><%= t('.monitoring') %></h3>
-      <dl>
-        <dt>http://<%= network_address %>/api/v1/config.json</dt>
-        <dd><%= t('.majestic_json') %></dd>
-        <dt>http://<%= network_address %>/metrics</dt>
-        <dd><%= t('.prometheus_html') %></dd>
-      </dl>
+  <div class="row">
+    <div class="col-lg-8">
+      <p><%= t('.moved_html') %></p>
+      <p><%= t('.why') %></p>
+      <ul>
+        <li><%= t('.reason_address') %></li>
+        <li><%= t('.reason_scheme') %></li>
+        <li><%= t('.reason_auth') %></li>
+      </ul>
+      <p>
+        <%= link_to t('.see_webui'), '/web-interface', class: 'btn btn-primary me-2' %>
+        <%= link_to t('.see_wiki'), 'https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md',
+                    class: 'btn btn-outline-secondary' %>
+      </p>
     </div>
   </div>
-
-  <ol class="footnotes small">
-    <li class="text-muted"><%= t('.footnote_1') %></li>
-    <li class="text-muted"><%= t('.footnote_2') %></li>
-    <li class="text-muted"><%= t('.footnote_3_html') %></li>
-    <li class="text-muted"><%= t('.footnote_4_html') %></li>
-  </ol>
-
-  <p class="text-muted"><%= t('.more_examples_html') %></p>
 </article>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -127,7 +127,6 @@ de:
     clone_soc: Klonen Sie diesen SoC
     dashboard: Armaturenbrett
     editing: Bearbeitung
-    endpoints: Majestätische Endpunkte
     green_life: Grünes Leben
     hires_timer: Hochauflösender Timer
     home: Heim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,7 +128,6 @@ en:
     clone_soc: Clone this SoC
     dashboard: Dashboard
     editing: Editing
-    endpoints: Majestic Endpoints
     green_life: Green Life
     hires_timer: High-Resolution Timer
     home: Home

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -127,7 +127,6 @@ es:
     clone_soc: Clonar este SoC
     dashboard: Panel
     editing: Edición
-    endpoints: Puntos finales majestuosos
     green_life: Vida verde
     hires_timer: Temporizador de alta resolución
     home: Hogar

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -127,7 +127,6 @@ fa:
     clone_soc: این SoC را شبیه سازی کنید
     dashboard: داشبورد
     editing: ویرایش
-    endpoints: نقاط پایانی با شکوه
     green_life: زندگی سبز
     hires_timer: تایمر با وضوح بالا
     home: صفحه اصلی

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -127,7 +127,6 @@ fr:
     clone_soc: Cloner ce SoC
     dashboard: Tableau de bord
     editing: Édition
-    endpoints: Points de terminaison majestueux
     green_life: Vie verte
     hires_timer: Minuterie haute résolution
     home: Maison

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -127,7 +127,6 @@ it:
     clone_soc: Clona questo SoC
     dashboard: Pannello di controllo
     editing: La modifica
-    endpoints: Endpoint maestosi
     green_life: Vita verde
     hires_timer: Temporizzatore ad alta risoluzione
     home: Casa

--- a/config/locales/pages.de.yml
+++ b/config/locales/pages.de.yml
@@ -57,47 +57,14 @@ de:
       development: Development
       title: Einführung
     majestic_endpoints:
-      aac: AAC-Audiostream.
-      accepts_post: Akzeptiert POST-Anfragen mit Audiodatei als Parameter.
-      alaw: A-Law-komprimierter Audiostream.
-      audio: Audio
-      dng: Schnappschuss im Adobe DNG-Format (roh).
-      fmp4: fMP4-Videostream.
-      footnote_1: Nur HiSilicon- und Goke-SoCs.
-      footnote_2: Nur HiSilicon SoCs v2 und höher.
-      footnote_3_html: ZB <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: ZB <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: G.711 A-Law-Audiostream.
-      heif: Schnappschuss im HEIF-Format.
-      hls: HLS-Live-Streaming im Webbrowser.
-      images: Standbilder
-      jpeg: Schnappschuss im JPEG-Format.
-      jpeg_params1: Breite, Höhe – Größe des resultierenden Bildes
-      jpeg_params2: qfactor – JPEG-Qualitätsfaktor (1-99)
-      jpeg_params3: color2gray – in Graustufen konvertieren
-      jpeg_params4: Zuschneiden – Das resultierende Bild wird auf 16x16x320x320 zugeschnitten
-      majestic_json: Tatsächliche Majestic-Konfiguration im JSON-Format.
-      mjpeg: MJPEG-Videostream.
-      mjpeg_player: MJPEG- und MP3-Live-Streaming im Webbrowser.
-      monitoring: Überwachung
-      more_examples_html: Weitere Beispiele finden Sie <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">in unserem Wiki</a> .
-      mp3: MP3-Audiostream.
-      night: Nacht-API
-      night_off: Schalten Sie den Nachtmodus aus.
-      night_on: Schalten Sie den Nachtmodus ein.
-      night_toggle: Aktuellen Nachtmodus umschalten.
-      optional_params: Optionale Parameter
-      opus: Opus-Audiostream.
-      play_on_speaker: Spielen Sie die Audiodatei über den Lautsprecher der Kamera ab.
-      prometheus_html: Knotenexporter für <a href="https://prometheus.io/">Prometheus</a> .
-      raw_pcm: Roher PCM-Audiostream.
-      rtsp0: RTSP-Hauptstream (video0).
-      rtsp1: RTSP-Substream (Video1).
-      title: Majestätische Endpunkte
-      ulaw: μ-Law-komprimierter Audiostream.
-      video: Video
-      webrtc: WebRTC-Live-Streaming im Webbrowser.
-      yuv420: Schnappschuss im YUV420-Format.
+      moved_html: 'Die Liste der Endpunkte, die Ihre Kamera bereitstellt, befindet sich jetzt in der Weboberfläche der Kamera selbst, auf der Seite <b>Majestic Endpoints</b>. Öffnen Sie <code>http://&lt;Kamera-Adresse&gt;/</code> im Browser und wählen Sie sie im Menü aus.'
+      reason_address: 'die echte Adresse Ihrer Kamera ist eingesetzt, sodass sich eine URL direkt in einen Player kopieren lässt;'
+      reason_auth: 'es ist ersichtlich, ob die Endpunkte ein Passwort verlangen oder ob die Authentifizierung ganz abgeschaltet ist.'
+      reason_scheme: 'das Schema passt zu Ihrer Einrichtung, http oder https und ws oder wss;'
+      see_webui: 'Weboberfläche ansehen'
+      see_wiki: 'Majestic im Wiki'
+      title: 'Majestic Endpoints'
+      why: 'Dort wird sie aus der tatsächlich laufenden Firmware erzeugt, was eine Seite auf dieser Website nicht leisten kann:'
     merchandise:
       order_from_weededwords: Bestellen Sie bei WeededWords.com
       shirt_1:

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -58,47 +58,14 @@ en:
       gaming: Gaming solutions
       title: Introduction
     majestic_endpoints:
-      aac: AAC audio stream.
-      accepts_post: Accepts POST requests with audio file as a parameter.
-      alaw: A-law compressed audio stream.
-      audio: Audio
-      dng: Snapshot in Adobe DNG format (raw).
-      fmp4: fMP4 video stream.
-      footnote_1: Only HiSilicon and Goke SoCs.
-      footnote_2: Only HiSilicon SoCs v2 and up.
-      footnote_3_html: E.g. <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: E.g. <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: G.711 A-law audio stream.
-      heif: Snapshot in HEIF format.
-      hls: HLS live-streaming in web browser.
-      images: Still Images
-      jpeg: Snapshot in JPEG format.
-      jpeg_params1: width, height - size of resulting image
-      jpeg_params2: qfactor - JPEG quality factor (1-99)
-      jpeg_params3: color2gray - convert to grayscale
-      jpeg_params4: crop - crop resulting image as 16x16x320x320
-      majestic_json: Actual Majestic config in JSON format.
-      mjpeg: MJPEG video stream.
-      mjpeg_player: MJPEG & MP3 live-streaming in web browser.
-      monitoring: Monitoring
-      more_examples_html: More examples available <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">in our wiki</a>.
-      mp3: MP3 audio stream.
-      night: Night API
-      night_off: Turn off night mode.
-      night_on: Turn on night mode.
-      night_toggle: Toggle current night mode.
-      optional_params: Optional parameters
-      opus: Opus audio stream.
-      play_on_speaker: Play audio file on camera's speaker.
-      prometheus_html: Node exporter for <a href="https://prometheus.io/">Prometheus</a>.
-      raw_pcm: Raw PCM audio stream.
-      rtsp0: RTSP main stream (video0).
-      rtsp1: RTSP substream (video1).
-      title: Majestic Endpoints
-      ulaw: μ-law compressed audio stream.
-      video: Video
-      webrtc: WebRTC live-streaming in web browser.
-      yuv420: Snapshot in YUV420 format.
+      moved_html: 'The list of endpoints your camera serves now lives in the camera''s own web interface, on the <b>Majestic Endpoints</b> page. Open <code>http://&lt;camera-address&gt;/</code> in a browser and choose it from the menu.'
+      reason_address: 'your camera''s real address is filled in, so a URL can be copied straight into a player;'
+      reason_auth: 'it says whether the endpoints ask for a password, or whether authentication has been switched off entirely.'
+      reason_scheme: 'the scheme matches your setup, http or https and ws or wss;'
+      see_webui: 'See the web interface'
+      see_wiki: 'Majestic in the wiki'
+      title: 'Majestic Endpoints'
+      why: 'It is generated there from the firmware that is actually running, which a page on this site cannot be:'
     merchandise:
       order_from_weededwords: Order from WeededWords.com
       shirt_1:

--- a/config/locales/pages.es.yml
+++ b/config/locales/pages.es.yml
@@ -57,47 +57,14 @@ es:
       development: Development
       title: Introducción
     majestic_endpoints:
-      aac: Transmisión de audio AAC.
-      accepts_post: Acepta solicitudes POST con archivo de audio como parámetro.
-      alaw: Transmisión de audio comprimida según la ley A.
-      audio: Audio
-      dng: Instantánea en formato Adobe DNG (sin formato).
-      fmp4: Transmisión de vídeo fMP4.
-      footnote_1: Solo SoC HiSilicon y Goke.
-      footnote_2: Solo HiSilicon SoC v2 y superiores.
-      footnote_3_html: Por ejemplo <i>, ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: Por ejemplo, <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: Transmisión de audio de ley A G.711.
-      heif: Instantánea en formato HEIF.
-      hls: Transmisión en vivo de HLS en el navegador web.
-      images: Imágenes fijas
-      jpeg: Instantánea en formato JPEG.
-      jpeg_params1: 'ancho, alto: tamaño de la imagen resultante'
-      jpeg_params2: qfactor - factor de calidad JPEG (1-99)
-      jpeg_params3: color2gray - convertir a escala de grises
-      jpeg_params4: 'crop: recorta la imagen resultante como 16x16x320x320'
-      majestic_json: Configuración real de Majestic en formato JSON.
-      mjpeg: Transmisión de vídeo MJPEG.
-      mjpeg_player: Transmisión en vivo de MJPEG y MP3 en el navegador web.
-      monitoring: Supervisión
-      more_examples_html: Más ejemplos disponibles <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">en nuestra wiki</a> .
-      mp3: Transmisión de audio MP3.
-      night: API nocturna
-      night_off: Desactiva el modo nocturno.
-      night_on: Activa el modo nocturno.
-      night_toggle: Alternar el modo nocturno actual.
-      optional_params: Parámetros opcionales
-      opus: Transmisión de audio de obra.
-      play_on_speaker: Reproduzca archivos de audio en el altavoz de la cámara.
-      prometheus_html: Exportador de nodos para <a href="https://prometheus.io/">Prometheus</a> .
-      raw_pcm: Transmisión de audio PCM sin formato.
-      rtsp0: Transmisión principal RTSP (video0).
-      rtsp1: Subtransmisión RTSP (video1).
-      title: Puntos finales majestuosos
-      ulaw: Flujo de audio comprimido según la ley μ.
-      video: Video
-      webrtc: Transmisión en vivo WebRTC en el navegador web.
-      yuv420: Instantánea en formato YUV420.
+      moved_html: 'La lista de puntos de acceso que sirve su cámara ahora vive en la interfaz web de la propia cámara, en la página <b>Majestic Endpoints</b>. Abra <code>http://&lt;dirección-de-la-cámara&gt;/</code> en el navegador y elíjala en el menú.'
+      reason_address: 'aparece la dirección real de su cámara, de modo que una URL puede copiarse directamente a un reproductor;'
+      reason_auth: 'indica si los puntos de acceso piden contraseña o si la autenticación está desactivada por completo.'
+      reason_scheme: 'el esquema coincide con su configuración, http o https y ws o wss;'
+      see_webui: 'Ver la interfaz web'
+      see_wiki: 'Majestic en la wiki'
+      title: 'Majestic Endpoints'
+      why: 'Allí se genera a partir del firmware que realmente está en ejecución, algo que una página de este sitio no puede hacer:'
     merchandise:
       order_from_weededwords: Haga su pedido desde WeededWords.com
       shirt_1:

--- a/config/locales/pages.fa.yml
+++ b/config/locales/pages.fa.yml
@@ -57,47 +57,14 @@ fa:
       development: Development
       title: معرفی
     majestic_endpoints:
-      aac: جریان صوتی AAC.
-      accepts_post: درخواست های POST را با فایل صوتی به عنوان پارامتر می پذیرد.
-      alaw: جریان صوتی فشرده A-law.
-      audio: سمعی
-      dng: عکس فوری با فرمت Adobe DNG (خام).
-      fmp4: جریان ویدئو fMP4.
-      footnote_1: فقط HiSilicon و Goke SoC.
-      footnote_2: فقط SoC های HiSilicon نسخه ۲ و بالاتر.
-      footnote_3_html: به عنوان مثال <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: به عنوان مثال <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: جریان صوتی G.711 A-law.
-      heif: عکس فوری با فرمت HEIF.
-      hls: پخش زنده HLS در مرورگر وب.
-      images: تصاویر ثابت
-      jpeg: عکس فوری با فرمت JPEG.
-      jpeg_params1: عرض، ارتفاع - اندازه تصویر حاصل
-      jpeg_params2: qfactor - فاکتور کیفیت JPEG (1-99)
-      jpeg_params3: color2gray - تبدیل به مقیاس خاکستری
-      jpeg_params4: برش - تصویر حاصل را به صورت 16x16x320x320 برش دهید
-      majestic_json: پیکربندی واقعی Majestic در فرمت JSON.
-      mjpeg: پخش ویدیوی MJPEG.
-      mjpeg_player: پخش زنده MJPEG و MP3 در مرورگر وب.
-      monitoring: نظارت بر
-      more_examples_html: نمونه های بیشتری <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">در ویکی ما</a> موجود است.
-      mp3: پخش صوتی MP3.
-      night: Night API
-      night_off: حالت شب را خاموش کنید.
-      night_on: حالت شب را روشن کنید.
-      night_toggle: حالت شب فعلی را تغییر دهید.
-      optional_params: پارامترهای اختیاری
-      opus: جریان صوتی Opus.
-      play_on_speaker: پخش فایل صوتی روی بلندگوی دوربین
-      prometheus_html: صادرکننده گره برای <a href="https://prometheus.io/">Prometheus</a> .
-      raw_pcm: جریان صوتی PCM خام.
-      rtsp0: جریان اصلی RTSP (video0).
-      rtsp1: جریان فرعی RTSP (video1).
-      title: نقاط پایانی با شکوه
-      ulaw: جریان صوتی فشرده با قانون μ.
-      video: ویدئو
-      webrtc: پخش زنده WebRTC در مرورگر وب.
-      yuv420: عکس فوری با فرمت YUV420.
+      moved_html: 'فهرست نقاط پایانی که دوربین شما ارائه می‌دهد اکنون در رابط وب خود دوربین، در صفحهٔ <b>Majestic Endpoints</b> قرار دارد. نشانی <code>http://&lt;آدرس-دوربین&gt;/</code> را در مرورگر باز کنید و آن صفحه را از منو انتخاب کنید.'
+      reason_address: 'نشانی واقعی دوربین شما در آن درج شده است، بنابراین می‌توان نشانی را مستقیماً در پخش‌کننده کپی کرد؛'
+      reason_auth: 'مشخص می‌کند که آیا نقاط پایانی رمز عبور می‌خواهند یا احراز هویت به‌کلی خاموش شده است.'
+      reason_scheme: 'طرح نشانی با پیکربندی شما هماهنگ است، http یا https و ws یا wss؛'
+      see_webui: 'مشاهدهٔ رابط وب'
+      see_wiki: 'Majestic در ویکی'
+      title: 'Majestic Endpoints'
+      why: 'آنجا این فهرست از میان‌افزاری که واقعاً در حال اجراست ساخته می‌شود، کاری که یک صفحه در این وب‌گاه نمی‌تواند انجام دهد:'
     merchandise:
       order_from_weededwords: از WeededWords.com سفارش دهید
       shirt_1:

--- a/config/locales/pages.fr.yml
+++ b/config/locales/pages.fr.yml
@@ -57,47 +57,14 @@ fr:
       development: Development
       title: Introduction
     majestic_endpoints:
-      aac: Flux audio AAC.
-      accepts_post: Accepte les requêtes POST avec un fichier audio comme paramètre.
-      alaw: Flux audio compressé conforme à la loi A.
-      audio: l'audio
-      dng: Instantané au format Adobe DNG (brut).
-      fmp4: Flux vidéo fMP4.
-      footnote_1: Uniquement les SoC HiSilicon et Goke.
-      footnote_2: Uniquement les SoC HiSilicon v2 et versions ultérieures.
-      footnote_3_html: Par exemple, <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: Par exemple <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: Flux audio G.711 loi A.
-      heif: Instantané au format HEIF.
-      hls: Diffusion en direct HLS dans un navigateur Web.
-      images: Images fixes
-      jpeg: Instantané au format JPEG.
-      jpeg_params1: largeur, hauteur - taille de l'image résultante
-      jpeg_params2: qfactor - Facteur de qualité JPEG (1-99)
-      jpeg_params3: color2gray - convertir en niveaux de gris
-      jpeg_params4: recadrer - recadrer l'image résultante en 16x16x320x320
-      majestic_json: Configuration Majestic réelle au format JSON.
-      mjpeg: Flux vidéo MJPEG.
-      mjpeg_player: Diffusion en direct MJPEG et MP3 dans un navigateur Web.
-      monitoring: Surveillance
-      more_examples_html: Plus d'exemples disponibles <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">dans notre wiki</a> .
-      mp3: Flux audio MP3.
-      night: API de nuit
-      night_off: Désactivez le mode nuit.
-      night_on: Activez le mode nuit.
-      night_toggle: Basculer le mode nuit actuel.
-      optional_params: Paramètres facultatifs
-      opus: Flux audio Opus.
-      play_on_speaker: Lisez le fichier audio sur le haut-parleur de la caméra.
-      prometheus_html: Exportateur de nœuds pour <a href="https://prometheus.io/">Prometheus</a> .
-      raw_pcm: Flux audio PCM brut.
-      rtsp0: Flux principal RTSP (vidéo0).
-      rtsp1: Sous-flux RTSP (vidéo1).
-      title: Points de terminaison majestueux
-      ulaw: Flux audio compressé selon la loi µ.
-      video: Vidéo
-      webrtc: Diffusion en direct WebRTC dans un navigateur Web.
-      yuv420: Instantané au format YUV420.
+      moved_html: 'La liste des points de terminaison servis par votre caméra se trouve désormais dans l’interface web de la caméra elle-même, sur la page <b>Majestic Endpoints</b>. Ouvrez <code>http://&lt;adresse-de-la-caméra&gt;/</code> dans un navigateur et sélectionnez-la dans le menu.'
+      reason_address: 'l’adresse réelle de votre caméra y est renseignée, de sorte qu’une URL peut être copiée directement dans un lecteur ;'
+      reason_auth: 'elle indique si les points de terminaison demandent un mot de passe ou si l’authentification est entièrement désactivée.'
+      reason_scheme: 'le schéma correspond à votre installation, http ou https et ws ou wss ;'
+      see_webui: 'Voir l’interface web'
+      see_wiki: 'Majestic dans le wiki'
+      title: 'Majestic Endpoints'
+      why: 'Elle y est générée à partir du micrologiciel réellement en cours d’exécution, ce qu’une page de ce site ne peut pas faire :'
     merchandise:
       order_from_weededwords: Commandez sur WeededWords.com
       shirt_1:

--- a/config/locales/pages.it.yml
+++ b/config/locales/pages.it.yml
@@ -57,47 +57,14 @@ it:
       development: Development
       title: introduzione
     majestic_endpoints:
-      aac: Flusso audio AAC.
-      accepts_post: Accetta richieste POST con file audio come parametro.
-      alaw: Flusso audio compresso A-law.
-      audio: Audio
-      dng: Istantanea in formato Adobe DNG (grezzo).
-      fmp4: flusso video fMP4.
-      footnote_1: Solo SoC HiSilicon e Goke.
-      footnote_2: Solo SoC HiSilicon v2 e versioni successive.
-      footnote_3_html: Ad esempio <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: Ad esempio <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: Flusso audio di legge G.711 A.
-      heif: Istantanea in formato HEIF.
-      hls: Streaming live HLS nel browser web.
-      images: Immagini fisse
-      jpeg: Istantanea in formato JPEG.
-      jpeg_params1: larghezza, altezza - dimensione dell'immagine risultante
-      jpeg_params2: qfactor - Fattore di qualità JPEG (1-99)
-      jpeg_params3: 'color2gray: converte in scala di grigi'
-      jpeg_params4: 'ritaglia: ritaglia l''immagine risultante come 16x16x320x320'
-      majestic_json: Configurazione effettiva di Majestic in formato JSON.
-      mjpeg: Flusso video MJPEG.
-      mjpeg_player: Streaming live MJPEG e MP3 nel browser web.
-      monitoring: Monitoraggio
-      more_examples_html: Altri esempi disponibili <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">nel nostro wiki</a> .
-      mp3: Flusso audio MP3.
-      night: API notturna
-      night_off: Disattiva la modalità notturna.
-      night_on: Attiva la modalità notturna.
-      night_toggle: Attiva/disattiva la modalità notturna corrente.
-      optional_params: Parametri facoltativi
-      opus: Flusso audio dell'Opus.
-      play_on_speaker: Riproduci il file audio sull'altoparlante della fotocamera.
-      prometheus_html: Esportatore di nodi per <a href="https://prometheus.io/">Prometheus</a> .
-      raw_pcm: Flusso audio PCM grezzo.
-      rtsp0: Flusso principale RTSP (video0).
-      rtsp1: Sottoflusso RTSP (video1).
-      title: Endpoint maestosi
-      ulaw: Flusso audio compresso a legge μ.
-      video: video
-      webrtc: Streaming live WebRTC nel browser web.
-      yuv420: Istantanea in formato YUV420.
+      moved_html: 'L''elenco degli endpoint serviti dalla telecamera si trova ora nell''interfaccia web della telecamera stessa, nella pagina <b>Majestic Endpoints</b>. Apri <code>http://&lt;indirizzo-telecamera&gt;/</code> nel browser e selezionala dal menu.'
+      reason_address: 'è già inserito l''indirizzo reale della telecamera, quindi un URL può essere copiato direttamente in un player;'
+      reason_auth: 'indica se gli endpoint richiedono una password o se l''autenticazione è disattivata del tutto.'
+      reason_scheme: 'lo schema corrisponde alla tua configurazione, http o https e ws o wss;'
+      see_webui: 'Guarda l''interfaccia web'
+      see_wiki: 'Majestic nella wiki'
+      title: 'Majestic Endpoints'
+      why: 'Lì viene generato dal firmware effettivamente in esecuzione, cosa che una pagina di questo sito non può fare:'
     merchandise:
       order_from_weededwords: Ordina da WeededWords.com
       shirt_1:

--- a/config/locales/pages.pl.yml
+++ b/config/locales/pages.pl.yml
@@ -57,47 +57,14 @@ pl:
       development: Development
       title: Wstęp
     majestic_endpoints:
-      aac: Strumień audio AAC.
-      accepts_post: Akceptuje żądania POST z plikiem audio jako parametrem.
-      alaw: Skompresowany strumień audio zgodny z prawem.
-      audio: Audio
-      dng: Zrzut ekranu w formacie Adobe DNG (surowy).
-      fmp4: Strumień wideo fMP4.
-      footnote_1: Tylko SoC HiSilicon i Goke.
-      footnote_2: Tylko HiSilicon SoC v2 i nowsze.
-      footnote_3_html: Np. <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: Np. <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: Strumień audio G.711 zgodny z prawem.
-      heif: Migawka w formacie HEIF.
-      hls: Transmisja na żywo HLS w przeglądarce internetowej.
-      images: Obrazy nieruchome
-      jpeg: Zrzut ekranu w formacie JPEG.
-      jpeg_params1: szerokość, wysokość - rozmiar powstałego obrazu
-      jpeg_params2: qfactor – współczynnik jakości JPEG (1-99)
-      jpeg_params3: color2gray - konwersja do skali szarości
-      jpeg_params4: przytnij - przytnij wynikowy obraz do rozmiaru 16x16x320x320
-      majestic_json: Rzeczywista konfiguracja Majestic w formacie JSON.
-      mjpeg: Strumień wideo MJPEG.
-      mjpeg_player: Transmisja na żywo w formacie MJPEG i MP3 w przeglądarce internetowej.
-      monitoring: Monitorowanie
-      more_examples_html: Więcej przykładów dostępnych jest <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">na naszej wiki</a> .
-      mp3: Strumień audio MP3.
-      night: Nocne API
-      night_off: Wyłącz tryb nocny.
-      night_on: Włącz tryb nocny.
-      night_toggle: Przełącz bieżący tryb nocny.
-      optional_params: Parametry opcjonalne
-      opus: Strumień audio Opusa.
-      play_on_speaker: Odtwórz plik audio na głośniku aparatu.
-      prometheus_html: Eksporter węzłów dla <a href="https://prometheus.io/">Prometheusa</a> .
-      raw_pcm: Surowy strumień audio PCM.
-      rtsp0: Główny strumień RTSP (wideo0).
-      rtsp1: Podstrumień RTSP (wideo 1).
-      title: Majestatyczne punkty końcowe
-      ulaw: skompresowany strumień audio μ-law.
-      video: Wideo
-      webrtc: Transmisja na żywo WebRTC w przeglądarce internetowej.
-      yuv420: Zrzut ekranu w formacie YUV420.
+      moved_html: 'Lista punktów końcowych udostępnianych przez kamerę znajduje się teraz w interfejsie webowym samej kamery, na stronie <b>Majestic Endpoints</b>. Otwórz w przeglądarce <code>http://&lt;adres-kamery&gt;/</code> i wybierz ją z menu.'
+      reason_address: 'wstawiony jest prawdziwy adres Twojej kamery, więc adres URL można skopiować wprost do odtwarzacza;'
+      reason_auth: 'widać, czy punkty końcowe proszą o hasło i czy uwierzytelnianie nie zostało całkiem wyłączone.'
+      reason_scheme: 'schemat odpowiada Twojej konfiguracji — http lub https oraz ws lub wss;'
+      see_webui: 'Zobacz interfejs webowy'
+      see_wiki: 'Majestic w wiki'
+      title: 'Majestic Endpoints'
+      why: 'Powstaje tam na podstawie faktycznie działającego oprogramowania układowego, czego strona w tym serwisie nie potrafi:'
     merchandise:
       order_from_weededwords: Zamów ze strony WeededWords.com
       shirt_1:

--- a/config/locales/pages.pt.yml
+++ b/config/locales/pages.pt.yml
@@ -57,47 +57,14 @@ pt:
       development: Development
       title: Introdução
     majestic_endpoints:
-      aac: Fluxo de áudio AAC.
-      accepts_post: Aceita solicitações POST com arquivo de áudio como parâmetro.
-      alaw: Fluxo de áudio compactado A-law.
-      audio: Áudio
-      dng: Instantâneo em formato Adobe DNG (bruto).
-      fmp4: Fluxo de vídeo fMP4.
-      footnote_1: Apenas SoCs HiSilicon e Goke.
-      footnote_2: Apenas HiSilicon SoCs v2 e superior.
-      footnote_3_html: Por exemplo <i>, ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: Por exemplo, <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: Fluxo de áudio G.711 A-law.
-      heif: Instantâneo em formato HEIF.
-      hls: Transmissão ao vivo HLS no navegador da web.
-      images: Imagens estáticas
-      jpeg: Instantâneo em formato JPEG.
-      jpeg_params1: largura, altura - tamanho da imagem resultante
-      jpeg_params2: qfactor - fator de qualidade JPEG (1-99)
-      jpeg_params3: color2gray - converte para escala de cinza
-      jpeg_params4: cortar - cortar a imagem resultante como 16x16x320x320
-      majestic_json: Configuração real do Majestic no formato JSON.
-      mjpeg: Fluxo de vídeo MJPEG.
-      mjpeg_player: Transmissão ao vivo de MJPEG e MP3 no navegador da web.
-      monitoring: Monitoramento
-      more_examples_html: Mais exemplos disponíveis <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">em nosso wiki</a> .
-      mp3: Fluxo de áudio MP3.
-      night: API noturna
-      night_off: Desligue o modo noturno.
-      night_on: Ative o modo noturno.
-      night_toggle: Alternar o modo noturno atual.
-      optional_params: Parâmetros opcionais
-      opus: Fluxo de áudio Opus.
-      play_on_speaker: Reproduza o arquivo de áudio no alto-falante da câmera.
-      prometheus_html: Exportador de nós para <a href="https://prometheus.io/">Prometheus</a> .
-      raw_pcm: Fluxo de áudio PCM bruto.
-      rtsp0: Fluxo principal RTSP (vídeo0).
-      rtsp1: Substream RTSP (vídeo1).
-      title: Terminais majestosos
-      ulaw: Fluxo de áudio compactado μ-law.
-      video: Vídeo
-      webrtc: Transmissão ao vivo WebRTC no navegador da web.
-      yuv420: Instantâneo no formato YUV420.
+      moved_html: 'A lista de endpoints que a sua câmara disponibiliza está agora na interface web da própria câmara, na página <b>Majestic Endpoints</b>. Abra <code>http://&lt;endereço-da-câmara&gt;/</code> no navegador e escolha-a no menu.'
+      reason_address: 'o endereço real da sua câmara já está preenchido, pelo que um URL pode ser copiado diretamente para um leitor;'
+      reason_auth: 'indica se os endpoints pedem palavra-passe ou se a autenticação está completamente desligada.'
+      reason_scheme: 'o esquema corresponde à sua configuração, http ou https e ws ou wss;'
+      see_webui: 'Ver a interface web'
+      see_wiki: 'Majestic na wiki'
+      title: 'Majestic Endpoints'
+      why: 'Aí é gerada a partir do firmware que está realmente em execução, o que uma página deste site não consegue fazer:'
     merchandise:
       order_from_weededwords: Encomende em WeededWords.com
       shirt_1:

--- a/config/locales/pages.ru.yml
+++ b/config/locales/pages.ru.yml
@@ -57,47 +57,14 @@ ru:
       development: Development
       title: Вступление
     majestic_endpoints:
-      aac: Аудиопоток AAC.
-      accepts_post: Принимает POST-запросы с аудиофайлом в качестве параметра.
-      alaw: Аудиопоток, сжатый по закону А.
-      audio: Аудио
-      dng: Снимок в формате Adobe DNG (сырой).
-      fmp4: Видеопоток fMP4.
-      footnote_1: Только SoC HiSilicon и Goke.
-      footnote_2: Только HiSilicon SoC v2 и выше.
-      footnote_3_html: Например, <i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: Например, <i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: Аудиопоток G.711 A-law.
-      heif: Снимок в формате HEIF.
-      hls: Прямая трансляция HLS в веб-браузере.
-      images: Фотографии
-      jpeg: Снимок в формате JPEG.
-      jpeg_params1: ширина, высота - размер результирующего изображения
-      jpeg_params2: qfactor - фактор качества JPEG (1-99)
-      jpeg_params3: color2gray - преобразовать в оттенки серого
-      jpeg_params4: кадрировать - обрезать полученное изображение до размера 16x16x320x320
-      majestic_json: Актуальная конфигурация Majestic в формате JSON.
-      mjpeg: Видеопоток MJPEG.
-      mjpeg_player: Прямая трансляция MJPEG и MP3 в веб-браузере.
-      monitoring: Мониторинг
-      more_examples_html: Другие примеры доступны <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">в нашей вики</a> .
-      mp3: Аудиопоток MP3.
-      night: Ночной API
-      night_off: Выключите ночной режим.
-      night_on: Включите ночной режим.
-      night_toggle: Переключить текущий ночной режим.
-      optional_params: Дополнительные параметры
-      opus: Аудиопоток Opus.
-      play_on_speaker: Воспроизведение аудиофайла на динамике камеры.
-      prometheus_html: Экспортер узлов для <a href="https://prometheus.io/">Prometheus</a>.
-      raw_pcm: Необработанный аудиопоток PCM.
-      rtsp0: Основной поток RTSP (video0).
-      rtsp1: Подпоток RTSP (видео1).
-      title: Величественные конечные точки
-      ulaw: Аудиопоток, сжатый по закону μ.
-      video: видео
-      webrtc: Прямая трансляция WebRTC в веб-браузере.
-      yuv420: Снимок в формате YUV420.
+      moved_html: 'Список эндпоинтов, которые отдаёт камера, теперь живёт в веб-интерфейсе самой камеры, на странице <b>Majestic Endpoints</b>. Откройте в браузере <code>http://&lt;адрес-камеры&gt;/</code> и выберите её в меню.'
+      reason_address: 'подставлен настоящий адрес вашей камеры, поэтому ссылку можно скопировать прямо в плеер;'
+      reason_auth: 'видно, спрашивают ли эндпоинты пароль и не отключена ли аутентификация полностью.'
+      reason_scheme: 'схема соответствует вашей настройке — http или https, ws или wss;'
+      see_webui: 'Посмотреть веб-интерфейс'
+      see_wiki: 'Majestic в вики'
+      title: 'Majestic Endpoints'
+      why: 'Там он собирается из реально работающей прошивки, чем страница на этом сайте быть не может:'
     merchandise:
       order_from_weededwords: Заказать на WeededWords.com
       shirt_1:

--- a/config/locales/pages.zh.yml
+++ b/config/locales/pages.zh.yml
@@ -57,47 +57,14 @@ zh:
       development: Development
       title: 介绍
     majestic_endpoints:
-      aac: AAC 音频流。
-      accepts_post: 接受带有音频文件作为参数的 POST 请求。
-      alaw: A-law 压缩音频流。
-      audio: 音频
-      dng: Adobe DNG 格式的快照 (raw)。
-      fmp4: fMP4 视频流。
-      footnote_1: 只有 HiSilicon 和 Goke SoC。
-      footnote_2: 仅限 HiSilicon SoC v2 及更高版本。
-      footnote_3_html: 例如<i>ffplay -ar 48000 -ac 1 -f s16le http://192.168.1.10/audio.pcm</i>
-      footnote_4_html: 例如<i>http://192.168.1.10/image.jpg?width=640&height=480&qfactor=50&color2gray=1&crop=80x32x512x400</i>
-      g711: G.711 A-law 音频流。
-      heif: HEIF 格式的快照。
-      hls: Web 浏览器中的 HLS 直播。
-      images: 图像
-      jpeg: JPEG 格式的快照。
-      jpeg_params1: width, height - 结果图像的大小
-      jpeg_params2: qfactor - JPEG 质量因子 (1-99)
-      jpeg_params3: color2gray - 转换为灰度
-      jpeg_params4: crop - 将生成的图像裁剪为 16x16x320x320
-      majestic_json: JSON 格式的 Majestic 配置。
-      mjpeg: MJPEG 视频流。
-      mjpeg_player: MJPEG 和 MP3 在 Web 浏览器中实时流式传输。
-      monitoring: 监控
-      more_examples_html: <a href="https://github.com/OpenIPC/wiki/blob/master/en/majestic-streamer.md">我们的 wiki 中</a>提供了更多示例。
-      mp3: MP3 音频流。
-      night: 夜间模式API
-      night_off: 关闭夜间模式。
-      night_on: 开启夜间模式。
-      night_toggle: 切换当前夜间模式。
-      optional_params: 可选参数
-      opus: Opus音频流。
-      play_on_speaker: 在相机的扬声器上播放音频文件。
-      prometheus_html: <a href="https://prometheus.io/">Prometheus</a>的节点导出器。
-      raw_pcm: 原始 PCM 音频流。
-      rtsp0: RTSP 主流 (video0)。
-      rtsp1: RTSP 子流 (video1)。
-      title: Majestic
-      ulaw: μ-law 压缩音频流。
-      video: 视频
-      webrtc: 网络浏览器中的 WebRTC 直播。
-      yuv420: YUV420 格式的快照。
+      moved_html: '摄像机提供的接口列表现在位于摄像机自身的 Web 界面中，即 <b>Majestic Endpoints</b> 页面。在浏览器中打开 <code>http://&lt;摄像机地址&gt;/</code>，然后从菜单中选择该页面。'
+      reason_address: '页面中填入的是您摄像机的真实地址，可以直接把链接复制到播放器；'
+      reason_auth: '页面会说明这些接口是否需要密码，以及认证是否被完全关闭。'
+      reason_scheme: '协议与您的配置一致，http 或 https、ws 或 wss；'
+      see_webui: '查看 Web 界面'
+      see_wiki: '维基中的 Majestic'
+      title: 'Majestic Endpoints'
+      why: '该页面由实际运行的固件生成，这是本站的静态页面无法做到的：'
     merchandise:
       order_from_weededwords: 从 WeededWords.com 订购
       shirt_1:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -127,7 +127,6 @@ pl:
     clone_soc: Sklonuj ten SoC
     dashboard: Panel
     editing: Redagowanie
-    endpoints: Majestatyczne punkty końcowe
     green_life: Zielone życie
     hires_timer: Timer o wysokiej rozdzielczości
     home: Dom

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -127,7 +127,6 @@ pt:
     clone_soc: Clonar este SoC
     dashboard: Painel
     editing: Edição
-    endpoints: Terminais majestosos
     green_life: Vida Verde
     hires_timer: Temporizador de alta resolução
     home: Lar

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -127,7 +127,6 @@ ru:
     clone_soc: Клонировать SoC
     dashboard: Приборная панель
     editing: Редактирование
-    endpoints: Majestic
     green_life: Зеленая жизнь
     hires_timer: Шустрый таймер
     home: Начало

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -127,7 +127,6 @@ zh:
     clone_soc: 克隆此 SoC
     dashboard: 仪表板
     editing: 编辑
-    endpoints: Majestic
     green_life: 绿色生活
     hires_timer: 高精度计时器
     home: 主页

--- a/test/controllers/majestic_endpoints_test.rb
+++ b/test/controllers/majestic_endpoints_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# The page used to carry the endpoint list in full. It fell behind the firmware
+# -- /ws/video, /nwebrtc, /api/v1/config.schema.json, /night/ircut and
+# /night/light all shipped without reaching it -- while the camera's own WebUI
+# builds the same list from the running build. So the list lives there now and
+# the page says where it went.
+#
+# The URL stays: it took roughly sixty-five requests a day in the fortnight
+# before this change, about half of them human, arriving from Google, from
+# OpenIPC/wiki and from other people's forum posts. Those are links we do not
+# control and should not break.
+class MajesticEndpointsTest < ActionDispatch::IntegrationTest
+  test 'the page still answers, so the inbound links keep working' do
+    get '/majestic-endpoints'
+    assert_response :success
+  end
+
+  test 'it sends the reader to the interface on the camera' do
+    get '/majestic-endpoints'
+    assert_select 'a[href=?]', '/web-interface'
+    assert_select 'article' do
+      assert_match(/Majestic Endpoints/, response.body)
+    end
+  end
+
+  test 'it no longer serves a copy of the list' do
+    get '/majestic-endpoints'
+
+    # The stale list was recognisable by its example address and its endpoint
+    # URLs; nothing that duplicates the device page should come back.
+    assert_no_match(/192\.168\.1\.10/, response.body)
+    assert_no_match(%r{rtsp://}, response.body)
+    assert_no_match(%r{/audio\.opus}, response.body)
+  end
+
+  test 'the navigation no longer offers it' do
+    get '/'
+    assert_response :success
+    assert_select 'a[href=?]', '/majestic-endpoints', false,
+                  'the menu still points at the page the list moved off'
+  end
+end


### PR DESCRIPTION
The maintainer's call: the endpoint list should live only in the device's own
interface. Checked it against the firmware and the WebUI before touching
anything, and the call holds.

## What was stale

Compared `app/views/pages/majestic_endpoints.html.erb` against the route table
in majestic's own source and against `mj-endpoints.cgi` in
`majestic-webui`. Missing from our page:

- the whole `ws://camera/ws/video` family — the low-latency fMP4/MSE stream the
  WebUI's own Preview runs on
- `/nwebrtc` (majestic's native stack, alongside `/webrtc` for KVS)
- `/api/v1/config.schema.json`
- `/night/ircut`, `/night/light`
- `/image.webp`, `rtsp://…/stream=2`

And the three things a static page structurally cannot do, which the device
page does: fill in the camera's real address, match the scheme (http/https,
ws/wss), and say whether authentication is on — or warn that `system.unsafe`
turned it off.

## Why the URL stays

`/majestic-endpoints` took **947 requests over the 15 days** of retained nginx
logs — ~65/day, flat. Roughly half is bots; the rest arrives from Google (91
referrals), from `OpenIPC/wiki`'s `en/majestic-streamer.md` (18), from our own
`/web-interface` (11), from the openipc.link mirror and from a Home Assistant
community thread. Those are links we don't control.

So this is not `/binaries`, which we closed with a 410 — that had 26 fetches a
fortnight and 25 of them were curl or Wget. The page keeps answering 200 and
tells the reader where the list went.

## Changes

- `majestic_endpoints.html.erb` becomes a short pointer to the camera's WebUI,
  with buttons to `/web-interface` and to the Majestic wiki page.
- The `nav.endpoints` dropdown entry goes, along with its key in all ten
  locales — it was machine-translated into nonsense in most of them anyway
  ("Majestätische Endpunkte", "Puntos finales majestuosos").
- The old `pages.majestic_endpoints.*` keys (44 of them per locale) are
  replaced by 8 new ones, translated in all ten locales. `i18n-tasks missing`
  and `i18n-tasks unused` report nothing new for these keys.
- New `test/controllers/majestic_endpoints_test.rb`: the page still answers,
  it points at `/web-interface`, it no longer serves a copy of the list, and
  the menu no longer offers it.
- **CI now builds the assets.** `app/assets/builds/` is gitignored, so on a
  fresh checkout sprockets raises "the asset is not present in the asset
  pipeline" for any test that renders a page through the layout — which is why
  the suite until now only covered redirects and exceptions. The new step is
  Node 20 + corepack + `yarn install --immutable` + `yarn build`/`build:css`,
  matching the Dockerfile.

## Verified locally

Docker, `ruby:3.1.7` + `mariadb:11.8`: **156 runs, 359 assertions, 0 failures,
0 errors**. Rubocop clean on the new file. All ten locales resolve.

## Follow-ups, not in this PR

- `OpenIPC/wiki` has two links into this page (`en/majestic-streamer.md:38`
  calls it "the full list of available endpoints", `en/menu-index.md:39`).
  Separate PR, coming next.
- `before_action :set_locale` in `Multilang` is still commented out, so
  `?locale=` does nothing and the site serves English whatever you ask for.
  The translations here are correct and ready for whenever that comes back on.
- `.rubocop.yml` requires `rubocop-performance`, which is not in the Gemfile —
  `bundle exec rubocop` cannot start. Unrelated to this change, but it means
  nobody is linting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Uo5RmXBdnWHT55pvant4q
