### PR TITLE
Flash the chip the visitor chose, not the SoC's default

### DIFF
--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -127,16 +127,7 @@ module Cameras
       elsif @camera.soc.model.in?(%w[HI3536CV100 HI3536DV100])
         render 'cameras/socs/hi3536dv100_is_weird'
       else
-        # Only when there is a Lite build to fall back to. hi3516cv6xx and
-        # hi3519dv500 are published as Ultimate and nothing else, so downgrading
-        # unconditionally would answer with instructions for a tarball that does
-        # not exist -- swapping a size problem the visitor can see for a missing
-        # file they cannot.
-        if @camera.flash_type.eql?('nor8m') && @camera.firmware_version.eql?('ultimate') &&
-           @camera.soc.available_releases('nor').include?('lite')
-          @camera.firmware_version = 'lite'
-          flash.now[:warning] = '8MB Flash ROM can only be flashed with Lite or FPV edition!'
-        end
+        enforce_eight_meg_limit
 
         # Everything above this point can be set from the query string.
         if (asked = @camera.use_published_release!)
@@ -242,6 +233,33 @@ module Cameras
       else
         # Both halves exist; this edition or flash type is the part that does not.
         'This firmware does not exist.'
+      end
+    end
+
+    # Ultimate does not fit an 8MB chip: its rootfs is larger than the 5120k
+    # `rootfs` partition mtdpartsnor8m defines, so `run urnor8m` cannot write it.
+    #
+    # Downgrade to Lite when there is a Lite build to downgrade to. Doing it
+    # unconditionally would be wrong -- hi3516cv6xx and hi3519dv500 are
+    # published as Ultimate and nothing else, and naming a Lite tarball upstream
+    # never built swaps a size problem the visitor can see for a missing file
+    # they cannot.
+    #
+    # When there is nothing to fall back to, say so rather than going quiet. The
+    # page otherwise rendered a full set of 8MB Ultimate instructions -- a
+    # download link for `flash_size=8&fw_release=ultimate`, and `run uknor8m;
+    # run urnor8m` -- with no indication that none of it can work.
+    def enforce_eight_meg_limit
+      return unless @camera.flash_type.eql?('nor8m') && @camera.firmware_version.eql?('ultimate')
+
+      if @camera.soc.available_releases('nor').include?('lite')
+        @camera.firmware_version = 'lite'
+        flash.now[:warning] = '8MB Flash ROM can only be flashed with Lite or FPV edition!'
+      else
+        flash.now[:danger] =
+          'The Ultimate edition does not fit an 8MB flash chip, and OpenIPC publishes no Lite build ' \
+          'for this SoC on NOR. These instructions cannot produce a working camera on 8MB flash -- ' \
+          'this SoC needs a larger chip.'
       end
     end
 

--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -100,10 +100,6 @@ module Cameras
       @camera.network_interface = permitted_params[:network_interface]
       @camera.sd_card_slot = permitted_params[:sd_card_slot]
 
-      # to handle nor32m size still using nor16m command
-      @flash_type_command = @camera.flash_type
-      @flash_type_command = 'nor16m' if @camera.flash_type.eql?('nor32m')
-
       @camera.soc = Soc.find(params[:id])
       @vendor = @camera.soc.vendor
 
@@ -111,7 +107,20 @@ module Cameras
       # upstream builds only a NAND image for -- rv1109 and rv1126 here today.
       # Their NOR sizes are disabled in the menu, so the form opened on a
       # disabled flash type with no edition to go with it.
-      @camera.flash_type = @camera.soc.default_flash_chip if params[:rom].blank?
+      #
+      # `show` guards this on params[:rom] because a query string is where its
+      # choice arrives. This action is reached by PUT from the form, which sends
+      # camera[flash_type] and never sends rom -- so the same guard here was
+      # always true and threw away every choice the visitor made.
+      @camera.flash_type = @camera.soc.default_flash_chip if permitted_params[:flash_type].blank?
+
+      # to handle nor32m size still using nor16m command. After the default
+      # above, not before: the commands name the chip, so reading the flash type
+      # first left the page telling a 16MB camera to `run urnor16m` and then
+      # erasing from the 8MB overlay offset, 733,184 bytes into what it had just
+      # written. That is the failure #60 described, by another route.
+      @flash_type_command = @camera.flash_type
+      @flash_type_command = 'nor16m' if @camera.flash_type.eql?('nor32m')
 
       if @vendor.name.eql?("SigmaStar") && @camera.flash_type.eql?("nand")
         render 'cameras/socs/sigmastar_nand_is_weird'

--- a/test/controllers/socs_controller_test.rb
+++ b/test/controllers/socs_controller_test.rb
@@ -152,4 +152,120 @@ class SocsControllerTest < ActionDispatch::IntegrationTest
       get "/cameras/vendors/#{@vendor.to_param}/socs/no-such-soc"
     end
   end
+
+  # --- the wizard renders the chip the visitor chose ---
+  #
+  # These render the whole installation page. That used to be impossible here --
+  # app/assets/builds/ is gitignored and sprockets raises on a missing
+  # application.css -- but CI now builds the assets before `bin/rails test`, and
+  # web_interface_test.rb and majestic_endpoints_test.rb already rely on it.
+
+  # Stub the release index with exactly these assets for the duration of the
+  # block. The installation page asks it what upstream publishes, and
+  # use_published_release! moves the visitor off an edition that is not there.
+  def with_release_index(*filenames)
+    root = Dir.mktmpdir
+    ENV['RELEASE_INDEX_ROOT'] = root
+    write_index(root, filenames)
+    ReleaseIndex.reset!
+    yield
+  ensure
+    ENV.delete('RELEASE_INDEX_ROOT')
+    ReleaseIndex.reset!
+    FileUtils.remove_entry(root) if root
+  end
+
+  def write_index(root, filenames)
+    assets = filenames.to_h { |name| [name, { 'size' => 1 }] }
+    File.write(File.join(root, '.index.json'),
+               JSON.generate('generated_at' => '2026-08-24T00:00:00Z', 'aliases' => {}, 'assets' => assets))
+  end
+
+  # Both editions on both flash types, so use_published_release! leaves the
+  # submitted choice alone and the assertions are about flash type and nothing
+  # else.
+  def every_edition_for(soc)
+    %w[nor nand].product(%w[lite ultimate]).map { |flash, release| "openipc.#{soc.board}-#{flash}-#{release}.tgz" }
+  end
+
+  def instructable_soc(model)
+    Soc.create!(vendor: @vendor, model:, status: 'done', load_address: '0x82000000',
+                uboot_filename: "u-boot-#{model.downcase}-universal.bin",
+                linux_filename: "openipc.#{model.downcase}-nor-lite.tgz")
+  end
+
+  def submit(soc, flash_type, firmware_version: 'lite')
+    put "/cameras/vendors/#{@vendor.to_param}/socs/#{soc.to_param}",
+        params: { camera: { flash_type:, firmware_version:,
+                            network_interface: 'eth', sd_card_slot: 'nosd',
+                            camera_ip_address: '192.168.1.10',
+                            server_ip_address: '192.168.1.254',
+                            camera_mac_address: '00:11:22:33:44:55' } }
+    assert_response :success
+  end
+
+  test 'a 16MB submission gets the 16MB layout, not the SoC default' do
+    # update guarded the default_flash_chip fallback on params[:rom], which is
+    # how `show` receives a choice and not how this action does: the form PUTs
+    # camera[flash_type] and never sends rom, so the guard was always true and
+    # every visitor was silently moved to nor8m. @flash_type_command was read
+    # before that happened, so the page said `run urnor16m` -- which writes the
+    # rootfs to 0x350000..0xd50000 -- and then erased from the 8MB overlay
+    # offset, 733,184 bytes inside it. Issue #60, by another route.
+    soc = instructable_soc('TS3516EV200')
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nor16m')
+
+      assert_match 'run setnor16m', response.body
+      assert_match 'run uknor16m; run urnor16m', response.body
+      assert_match 'sf erase 0xD50000', response.body
+      assert_no_match(/sf erase 0x750000/, response.body)
+    end
+  end
+
+  test 'an 8MB submission still gets the 8MB layout' do
+    soc = instructable_soc('TS3518EV200')
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nor8m')
+
+      assert_match 'run uknor8m; run urnor8m', response.body
+      assert_match 'sf erase 0x750000', response.body
+    end
+  end
+
+  test 'a NAND submission is not turned into a NOR one' do
+    # default_flash_chip answers nor8m for any SoC with a NOR build, so this
+    # combination rendered `run uknand; run urnand` followed by an `sf erase`:
+    # Camera#nand? was false, and the erase is meaningless on a UBI partition.
+    soc = instructable_soc('TS3516CV500')
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nand')
+
+      assert_match 'run setnand', response.body
+      assert_match 'run uknand; run urnand', response.body
+      assert_no_match(/sf erase/, response.body)
+    end
+  end
+
+  test 'a submission with no flash type still falls back to what the SoC has' do
+    # What the guard was there for: rv1109 and rv1126 publish only a NAND image,
+    # their NOR sizes are disabled in the menu, and nor8m is the wrong place to
+    # start. Nothing on NOR here, so default_flash_chip answers nand -- and the
+    # commands have to follow it, which is why @flash_type_command is read after
+    # the fallback rather than before. It used to render a bare `run set`.
+    soc = Soc.create!(vendor: @vendor, model: 'TS1126', status: 'done',
+                      load_address: '0x82000000',
+                      uboot_filename: 'u-boot-ts1126-universal.bin',
+                      linux_filename: 'openipc.ts1126-nand-ultimate.tgz')
+
+    with_release_index('openipc.ts1126-nand-ultimate.tgz') do
+      submit(soc, '', firmware_version: 'ultimate')
+
+      assert_match 'run setnand', response.body
+      assert_match 'run uknand; run urnand', response.body
+    end
+  end
 end

--- a/test/controllers/socs_controller_test.rb
+++ b/test/controllers/socs_controller_test.rb
@@ -268,4 +268,20 @@ class SocsControllerTest < ActionDispatch::IntegrationTest
       assert_match 'run uknand; run urnand', response.body
     end
   end
+
+  test '8MB with only an Ultimate build says so instead of rendering it silently' do
+    # Ultimate does not fit 8MB. The downgrade to Lite is conditional on a Lite
+    # build existing, which is right -- hi3516cv6xx and hi3519dv500 publish
+    # Ultimate and nothing else, and downgrading regardless would name a tarball
+    # upstream never built. But with nothing to fall back to the page went on to
+    # render `run urnor8m`, which erases a 5120k rootfs partition, for a rootfs
+    # that cannot fit in it, and said nothing about it.
+    soc = instructable_soc('TS3519DV500')
+
+    with_release_index("openipc.#{soc.board}-nor-ultimate.tgz") do
+      submit(soc, 'nor8m', firmware_version: 'ultimate')
+
+      assert_match(/does not fit an 8MB flash chip/, response.body)
+    end
+  end
 end


### PR DESCRIPTION
`Cameras::SocsController#update` guarded the `default_flash_chip` fallback on
`params[:rom]`:

```ruby
@camera.flash_type = @camera.soc.default_flash_chip if params[:rom].blank?
```

That is how `show` receives a choice — a query string. It is not how `update`
does. The wizard form is `bootstrap_form_for @camera, url:
cameras_vendor_soc_path(...), method: 'put'`, so it PUTs `camera[flash_type]`
and never sends `rom`. The guard was therefore always true, and every
submission was moved to `default_flash_chip` — `nor8m` for any SoC with a NOR
build — whatever the visitor picked.

`@flash_type_command` was read *before* that overwrite, so the commands and the
offsets disagreed. Choosing 16MB rendered:

```
run setnor16m
run uknor16m; run urnor16m      # writes the rootfs to 0x350000..0xd50000
sf erase 0x750000 0x8b0000      # the 8MB overlay offset
```

which is #60's failure — erasing 733,184 bytes into a rootfs written moments
earlier — reintroduced through a different door after #78 had fixed it.

Collateral on the same path: `mw.b … 0xff 0x800000` instead of `0x1000000`, a
`backup_filename` saying `nor8m`, and the "8MB Flash ROM can only be flashed
with Lite" downgrade firing for every NOR SoC whatever chip was chosen.
Choosing NAND on a SoC that also has NOR builds emitted `run uknand; run
urnand` followed by an `sf erase`, because `Camera#nand?` was false. Submitting
no flash type rendered a bare `run set`.

## The change

Guard on the form field, and read the command set after the flash type has
settled rather than before. `show` keeps its `params[:rom]` guard, which is
correct there.

## Tests

Four tests on `update`, which had none. They render the whole installation
page — newly possible, since CI now builds the assets before `bin/rails test`;
the "no test renders a page here" note in that file was stale.

Three of the four fail on `master` and pass here. The 8MB one passes either
way, which is the point: `nor8m` is what `master` forced everyone to.

Verified locally against the CI recipe (ruby 3.1.7 + mariadb): 174 runs, 637
assertions, 0 failures.

Closes the regression introduced in #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFg9PRy2T6cr983S8gran5