### PR TITLE
Offer Ultimate on the only chip it is built for

### DIFF
--- a/app/models/camera.rb
+++ b/app/models/camera.rb
@@ -190,7 +190,7 @@ class Camera
   # which agreed with the bootloader only for 8MB+Lite and 16MB+Ultimate; see
   # FlashLayout for what that cost on 16MB.
   def nor_layout
-    FlashLayout.nor(flash_size, soc&.vendor&.name)
+    FlashLayout.nor(flash_size)
   end
 
   def kernel_max_size

--- a/app/models/firmware.rb
+++ b/app/models/firmware.rb
@@ -391,7 +391,7 @@ class Firmware
   # Same table the installation page renders from, so the image and the
   # instructions cannot describe different partition layouts.
   def nor_layout
-    @nor_layout ||= FlashLayout.nor(@size, @soc.vendor.name)
+    @nor_layout ||= FlashLayout.nor(@size)
   end
 
   def kernel_offset

--- a/app/models/flash_layout.rb
+++ b/app/models/flash_layout.rb
@@ -33,19 +33,30 @@ class FlashLayout
             overlay_offset: 0xD50000 }.freeze
   }.freeze
 
-  # These two keep the 8MB offsets whatever the chip size. The rule is carried
-  # over unchanged from Firmware#rootfs_offset, which has applied it for as long
-  # as the method has existed; it is preserved rather than revisited because
-  # neither u-boot-sigmastar nor u-boot-ingenic defines the uknor/urnor macros
-  # the others do, so there is nothing upstream to check it against. Worth
-  # confirming with the firmware maintainers before anyone relies on it further.
-  # The view already treats the same two vendors specially when rendering the
-  # environment-preparation step.
-  EIGHT_MEG_LAYOUT_VENDORS = %w[SigmaStar Ingenic].freeze
-
-  def self.nor(flash_size_mb, vendor_name = nil)
-    return NOR[8] if EIGHT_MEG_LAYOUT_VENDORS.include?(vendor_name)
-
+  # SigmaStar and Ingenic used to be pinned to the 8MB offsets whatever chip was
+  # chosen, on the grounds that their bootloaders defined no uknor/urnor macros
+  # to check against. They do. The repositories checked were u-boot-sigmastar
+  # and u-boot-ingenic, which are not what those SoCs ship; the real ones are
+  # per-SoC, and u-boot-t20, u-boot-t40 and u-boot-msc313e all carry the same
+  # pair as the Hisilicon and Goke bootloaders above, down to the byte:
+  #
+  #   mtdpartsnor16m = 256k(boot),64k(env),3072k(kernel),10240k(rootfs),-(rootfs_data)
+  #   uknor16m : sf erase 0x50000 0x300000    urnor16m : sf erase 0x350000 0xa00000
+  #
+  # Only the mtd device name differs -- jz_sfc, NOR_FLASH, sfc.
+  #
+  # The pin also could not survive Ultimate on 16MB. Ultimate's NOR rootfs is
+  # 7820KB on ssc338q and 6752KB on t31, and the 8MB layout gives rootfs 5120KB.
+  # There is no arrangement in which those two vendors offer Ultimate on a 16MB
+  # chip and keep the 8MB geometry.
+  #
+  # This is the one place the chip size decides, for every vendor. What has to
+  # travel with it is the instruction to run `setnor16m`: every one of these
+  # bootloaders defaults mtdparts to the 8MB layout, and flashing a full image
+  # leaves the env erased, so a 16MB camera that is never told to switch boots
+  # with 8MB partitions. update.html.erb used to suppress that instruction for
+  # these same two vendors and no longer does.
+  def self.nor(flash_size_mb)
     flash_size_mb.to_i <= 8 ? NOR[8] : NOR[16]
   end
 end

--- a/app/views/cameras/socs/show.html.erb
+++ b/app/views/cameras/socs/show.html.erb
@@ -110,9 +110,17 @@
     );
 
     // Flash size still constrains the edition independently of what exists:
-    // an 8MB part cannot hold Ultimate whether or not it is published. Kept
-    // exactly as it was.
-    const sizeLimits = {nor8m: ['lite'], nor16m: ['lite']};
+    // an 8MB part cannot hold Ultimate whether or not it is published.
+    //
+    // 16MB used to be listed here too, and that was wrong. Ultimate is built
+    // for 16MB and for nothing else -- all 28 *_ultimate_defconfig files
+    // upstream carry BR2_OPENIPC_FLASH_SIZE="16" -- and the build caps a NOR
+    // rootfs at 8192KB against a 10240KB partition, so it cannot overflow. The
+    // published images run 6728-7928KB. Listing 16MB here hid the edition from
+    // exactly the hardware it targets. With the entry gone, allowedEditions
+    // falls through to what the release index says is published, which is the
+    // rule: both editions on 16MB where an Ultimate image exists.
+    const sizeLimits = {nor8m: ['lite']};
 
     // What to land on when the current choice is no longer available.
     const preferred = {nor32m: 'ultimate', nand: 'ultimate'};

--- a/app/views/cameras/socs/update.html.erb
+++ b/app/views/cameras/socs/update.html.erb
@@ -69,7 +69,15 @@
           <% end %>
           <%= flashing_everything(@camera) %>
           <p><%= t('firmware.installation.flashing_full.continue') %></p>
-          <% unless @camera.soc.vendor.name.eql?('SigmaStar') || @camera.soc.vendor.name.eql?('Ingenic') || @flash_type_command.eql?('nor8m') %>
+          <%# SigmaStar and Ingenic were exempted here in 64d37db and 00332d1 and
+              are not any more. Their bootloaders default mtdparts to the 8MB
+              layout like every other one, a full-image flash leaves the env
+              erased so that default is what the camera boots with, and the
+              expert section below has always told them to run setnor16m
+              regardless -- so the exemption made this page contradict itself.
+              It also cannot coexist with Ultimate on 16MB: that rootfs is
+              7820KB on ssc338q against the 5120KB the 8MB layout allows. %>
+          <% unless @flash_type_command.eql?('nor8m') %>
             <p><%= t('firmware.installation.flashing_full.continue2') %></p>
             <%= preparing_environment(@flash_type_command) %>
           <% end %>

--- a/test/controllers/socs_controller_test.rb
+++ b/test/controllers/socs_controller_test.rb
@@ -195,7 +195,7 @@ class SocsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def submit(soc, flash_type, firmware_version: 'lite')
-    put "/cameras/vendors/#{@vendor.to_param}/socs/#{soc.to_param}",
+    put "/cameras/vendors/#{soc.vendor.to_param}/socs/#{soc.to_param}",
         params: { camera: { flash_type:, firmware_version:,
                             network_interface: 'eth', sd_card_slot: 'nosd',
                             camera_ip_address: '192.168.1.10',
@@ -443,5 +443,111 @@ class SocsControllerTest < ActionDispatch::IntegrationTest
     ENV.delete('RELEASE_INDEX_ROOT')
     ReleaseIndex.reset!
     FileUtils.remove_entry(root) if root
+  end
+
+  # --- Ultimate on a 16MB chip ---
+
+  # The edition menu forbade Ultimate on 16MB, and 16MB is the only chip
+  # Ultimate is built for: every *_ultimate_defconfig upstream carries
+  # BR2_OPENIPC_FLASH_SIZE="16". The rule hid the edition from the hardware it
+  # targets. It cannot overflow either -- the build caps a NOR rootfs at 8192KB
+  # and the 16MB layout gives it 10240KB.
+  test 'the edition menu no longer withholds Ultimate from a 16MB chip' do
+    soc = instructable_soc('TS3516EV500')
+
+    with_release_index(*every_edition_for(soc)) do
+      get "/cameras/vendors/#{@vendor.to_param}/socs/#{soc.to_param}"
+
+      assert_response :success
+      assert_match(/const sizeLimits = \{nor8m: \['lite'\]\};/, response.body)
+    end
+  end
+
+  test 'Ultimate on 16MB is rendered as Ultimate, not quietly downgraded' do
+    soc = instructable_soc('TS3516EV600')
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nor16m', firmware_version: 'ultimate')
+
+      assert_match 'openipc-ts3516ev600-nor-ultimate-16mb.bin', response.body
+      assert_no_match(/8MB Flash ROM can only be flashed/, response.body)
+      assert_no_match(/does not fit an 8MB flash chip/, response.body)
+    end
+  end
+
+  test '8MB still refuses Ultimate, so the size rule was narrowed and not dropped' do
+    soc = instructable_soc('TS3516EV700')
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nor8m', firmware_version: 'ultimate')
+
+      assert_match(/8MB Flash ROM can only be flashed/, response.body)
+      assert_match 'openipc-ts3516ev700-nor-lite-8mb.bin', response.body
+    end
+  end
+
+  # --- SigmaStar and Ingenic on 16MB ---
+
+  # FlashLayout pinned these two vendors to the 8MB offsets whatever chip was
+  # picked, so the page told a 16MB camera to `run uknor16m; run urnor16m` --
+  # writing the rootfs to 0x350000..0xd50000 using the bootloader's own macros
+  # -- and then erased from 0x750000, 733,184 bytes inside it. u-boot-msc313e,
+  # u-boot-t20 and u-boot-t40 all define mtdpartsnor16m identically to the
+  # Hisilicon and Goke ones, so there was never a reason to treat them apart.
+  def soc_of(vendor_name)
+    vendor = Vendor.create!(name: vendor_name)
+    Soc.create!(vendor:, model: 'TS338Q', status: 'done', load_address: '0x82000000',
+                uboot_filename: 'u-boot-ts338q-universal.bin',
+                linux_filename: 'openipc.ts338q-nor-lite.tgz')
+  end
+
+  # FlashLayout pinned these two vendors to the 8MB offsets whatever chip was
+  # picked, so the page told a 16MB camera to `run uknor16m; run urnor16m` --
+  # writing the rootfs to 0x350000..0xd50000 using the bootloader's own macros
+  # -- and then erased from 0x750000, 733,184 bytes inside it.
+  def assert_sixteen_meg_offsets(vendor_name)
+    soc = soc_of(vendor_name)
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nor16m', firmware_version: 'ultimate')
+
+      assert_match 'sf erase 0xD50000', response.body
+      assert_no_match(/sf erase 0x750000/, response.body)
+    end
+  end
+
+  # Those offsets are only right if the camera is running the 16MB mtdparts, and
+  # every one of these bootloaders defaults to the 8MB one. A full-image flash
+  # leaves the env erased, so that default is what boots. These two vendors used
+  # to be the only ones not told to run setnor16m afterwards.
+  def assert_told_to_remap_partitions(vendor_name)
+    soc = soc_of(vendor_name)
+
+    with_release_index(*every_edition_for(soc)) do
+      submit(soc, 'nor16m')
+
+      # The expert section further down emits `run setnor16m` for everybody and
+      # always has, so matching the string alone proves nothing. What was
+      # suppressed is the copy of it in the full-image section, which arrives
+      # with the flashing_full.continue2 sentence in front of it.
+      assert_match 'remap ROM partitioning according to your flash size', response.body
+      assert_equal 2, response.body.scan('run setnor16m').size
+    end
+  end
+
+  test 'a 16MB SigmaStar submission gets the 16MB layout like everyone else' do
+    assert_sixteen_meg_offsets('SigmaStar')
+  end
+
+  test 'a 16MB Ingenic submission gets the 16MB layout like everyone else' do
+    assert_sixteen_meg_offsets('Ingenic')
+  end
+
+  test 'a 16MB SigmaStar camera is told to run setnor16m after a full flash' do
+    assert_told_to_remap_partitions('SigmaStar')
+  end
+
+  test 'a 16MB Ingenic camera is told to run setnor16m after a full flash' do
+    assert_told_to_remap_partitions('Ingenic')
   end
 end

--- a/test/models/firmware_test.rb
+++ b/test/models/firmware_test.rb
@@ -481,15 +481,22 @@ class FirmwareTest < ActiveSupport::TestCase
     end
   end
 
-  test 'the vendors that keep the 8MB offsets keep them in both places' do
-    %w[SigmaStar Ingenic].each do |vendor|
+  # These two used to be pinned to the 8MB offsets whatever chip was chosen, so
+  # this asserted 0x250000. u-boot-msc313e, u-boot-t20 and u-boot-t40 all define
+  # mtdpartsnor16m exactly as the Hisilicon and Goke bootloaders do, and their
+  # Ultimate rootfs -- 7820KB on ssc338q -- does not fit the 5120KB the 8MB
+  # layout allows, so the pin could not survive Ultimate on 16MB either. What
+  # this test is for is unchanged: the image and the page must not describe
+  # different layouts, whichever offsets are right.
+  test 'no vendor gets offsets of its own: image and page agree on 16MB' do
+    %w[SigmaStar Ingenic HiSilicon].each do |vendor|
       fw = build(model: 'ssc338q', vendor: vendor, flash_type: 'nor', size: 16, release: 'lite',
                  members: { 'uImage.ssc338q' => KERNEL, 'rootfs.squashfs.ssc338q' => SQUASHFS })
       fw.generate
 
       camera = Camera.new(flash_type: 'nor16m', firmware_version: 'lite', soc: fw_soc(vendor))
-      assert_equal '0x250000', camera.rootfs_offset, "#{vendor} lost its 8MB rootfs offset"
-      assert_equal SQUASHFS, IO.binread(fw.filepath)[0x250000, SQUASHFS.bytesize],
+      assert_equal '0x350000', camera.rootfs_offset, "#{vendor} is not on the 16MB rootfs offset"
+      assert_equal SQUASHFS, IO.binread(fw.filepath)[0x350000, SQUASHFS.bytesize],
                    "#{vendor}: the image does not match the page"
     end
   end


### PR DESCRIPTION
Closes #109.

## The edition rule

`show.html.erb` declared `sizeLimits = {nor8m: ['lite'], nor16m: ['lite']}`.
The `nor16m` half was wrong, and it hid the flagship edition from exactly
the hardware that edition targets.

Ultimate is a 16MB-only build. All 28 `*_ultimate_defconfig` files upstream
carry `BR2_OPENIPC_FLASH_SIZE="16"`; not one says 8. The `repack` target
picks the rootfs cap from that value, `CHECK_SIZE` fails the build above it,
and the cap for anything that is not size 8 is **8192KB** against a
**10240KB** partition — so overflow is structurally impossible, not merely
unobserved. Measured on the tarballs of the latest release:

| board | rootfs | kernel | partition |
|---|---|---|---|
| gk7205v200 | 6728KB | 1815KB | 10240 / 3072 |
| hi3516ev300 | 7928KB | 2048KB | 10240 / 3072 |
| ssc338q | 7820KB | 2025KB | 10240 / 3072 |
| t31 | 6752KB | 1786KB | 10240 / 3072 |

Dropping the entry makes `allowedEditions('nor16m')` fall through to the
release index, which is the rule as stated: both editions on 16MB where an
Ultimate image exists. 8MB keeps its limit, and `enforce_eight_meg_limit`
server-side is untouched.

## Why the layout change had to come with it

`FlashLayout::EIGHT_MEG_LAYOUT_VENDORS` pinned SigmaStar and Ingenic to the
8MB offsets whatever chip was chosen — a 5120KB rootfs partition. ssc338q's
Ultimate rootfs is 7820KB. Relaxing `sizeLimits` alone would have exposed a
corrupting write rather than fixed anything, so the two land together.

The pin's stated reason was that those bootloaders define no `uknor`/`urnor`
macros. They do — the repositories checked were `u-boot-sigmastar` and
`u-boot-ingenic`, which are not what those SoCs ship. The real ones are
per-SoC and carry the same pair as the Hisilicon and Goke bootloaders the
site already trusts, byte for byte:

| | `mtdpartsnor16m` | `urnor16m` |
|---|---|---|
| `u-boot-gk7205v200` | `sfc:256k,64k,3072k,10240k,-` | `sf erase 0x350000 0xa00000` |
| `u-boot-t20` / `u-boot-t40` | `jz_sfc:256k,64k,3072k,10240k,-` | `sf erase 0x350000 0xa00000` |
| `u-boot-msc313e` | `NOR_FLASH:256k,64k,3072k,10240k,-` | `sf erase 0x350000 0xa00000` |

Only the mtd device name differs.

## The live bug this uncovers

The vendor suppression at `update.html.erb:72` covers the full-image section
only. Lines 119 and 142 never had a vendor guard, so a **16MB SigmaStar or
Ingenic camera has been getting**:

```
run setnor16m
run uknor16m; run urnor16m      # rootfs -> 0x350000..0xd50000
sf erase 0x750000 0x8b0000      # 733,184 bytes inside it
```

That is #60's exact failure, for the two vendors #78 did not reach. It is
broken under *either* answer to the question below — the page contradicts
itself within three lines.

## The one thing I want a second opinion on

Lifting the pin means these cameras must run `setnor16m`, because every one
of these bootloaders defaults `mtdparts` to the **8MB** layout in
`CONFIG_EXTRA_ENV_SETTINGS` and a full-image flash leaves the env partition
erased, so that compiled-in default is what boots. So this PR also removes
the SigmaStar/Ingenic exemption from `update.html.erb:72`.

**That reverses a deliberate decision** — 64d37db (themactep, Dec 2023,
"16mb fpv on sigmastar, remove run setnor8m") and 00332d1, which extended it
to Ingenic. I could not recover the reason from either commit. The arithmetic
above forces the outcome if Ultimate is to be offered on 16MB at all, but if
there is a reason those two vendors were left alone that I have not found,
this is the hunk to push back on.

## Verification

`bin/rails test` — 192 runs, 718 assertions, 0 failures (185 before).
`rubocop` on the touched files introduces no new offence; the only delta is
the pre-existing `Metrics/ClassLength` on the test class counting higher.

Every new test was checked by reverting its fix:

| revert | fails |
|---|---|
| `nor16m` back in `sizeLimits` | 1 (menu) |
| `EIGHT_MEG_LAYOUT_VENDORS` back | 3 (2 controller, 1 firmware) |
| vendor suppression back in the view | 2 |

The `setnor16m` test passed under revert on the first attempt, because the
expert section emits the same string for everyone; it now asserts the
`flashing_full.continue2` sentence and counts occurrences.

`test/models/firmware_test.rb`'s "the vendors that keep the 8MB offsets keep
them in both places" asserted the old behaviour and is rewritten. What it
was for — the image and the page must not describe different layouts — is
unchanged, and it now covers HiSilicon alongside the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFg9PRy2T6cr983S8gran5