### PR TITLE
Treat a blank edition in a permanent link as no edition

### DIFF
--- a/app/controllers/cameras/socs_controller.rb
+++ b/app/controllers/cameras/socs_controller.rb
@@ -244,8 +244,15 @@ module Cameras
       # copied, and it is applied whether or not the link carried one.
       camera.camera_mac_address = params[:mac].to_s.downcase.gsub('-', ':')
 
+      # present?, not just presence of the key. A permanent link carries every
+      # field whether or not it has a value, so `?...&ver=&sd=` is what a link
+      # built from a camera with no edition chosen looks like -- and the menu
+      # can produce exactly that, since allowedEditions falls back to '' when a
+      # chip has nothing published for it. Treating the empty string as an
+      # answer blanked the dropdown; blank means "not specified", so the
+      # constructor default stands.
       PERMALINK_FIELDS.each do |key, field|
-        camera.public_send("#{field}=", params[key]) if params[key]
+        camera.public_send("#{field}=", params[key]) if params[key].present?
       end
     end
 

--- a/test/controllers/socs_controller_test.rb
+++ b/test/controllers/socs_controller_test.rb
@@ -626,6 +626,32 @@ class SocsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # A permanent link names every field whether or not it has a value, so
+  # `&ver=` is what a link built with no edition chosen looks like -- and the
+  # menu produces exactly that, because allowedEditions falls back to '' for a
+  # chip with nothing published. OpenIPC/firmware#1912 carries a real one.
+  # Reading the empty string as an answer left the dropdown with nothing
+  # selected at all.
+  def assert_blank_edition_key_ignored(key, model)
+    soc = instructable_soc(model)
+
+    with_release_index(*every_edition_for(soc)) do
+      get "/cameras/vendors/#{soc.vendor.to_param}/socs/#{soc.to_param}" \
+          "?mac=aa-bb-cc-dd-ee-ff&cip=10.0.0.5&sip=10.0.0.1&net=both&rom=nor16m&#{key}=&sd=sd"
+
+      assert_response :success
+      assert_match %(<option selected="selected" value="lite">), response.body
+    end
+  end
+
+  test 'an empty var= in a link is no edition rather than a blank one' do
+    assert_blank_edition_key_ignored('var', 'TS3516EVC00')
+  end
+
+  test 'an empty ver= in a link is no edition rather than a blank one' do
+    assert_blank_edition_key_ignored('ver', 'TS3516EVC10')
+  end
+
   test 'a link shared before the spelling was fixed still carries its edition' do
     soc = instructable_soc('TS3516EV900')
 


### PR DESCRIPTION
Regression from #114, found while triaging website bugs filed against
`OpenIPC/firmware`.

A permanent link names every field whether or not it has a value. `OpenIPC/firmware#1912`
carries a real one:

```
https://openipc.org/cameras/vendors/sigmastar/socs/ssc338q?mac=…&rom=nand&var=&sd=sd
```

`var=` with nothing after it. The menu produces exactly that, because
`allowedEditions` falls back to `''` for a chip with nothing published, and the
form then posts an empty edition.

`if params[key]` treats `""` as an answer, so `firmware_version` became `""` and
the dropdown rendered with **nothing selected**:

```
&var=      -> selected ["nor16m"]
&ver=      -> selected ["nor16m"]
&var=lite  -> selected ["nor16m", "lite"]
```

Before #114 this was unreachable — `show` read `ver`, which `permalink` never
wrote, so an empty `var=` was ignored and the `lite` constructor default stood.
Accepting `var` and emitting `ver` made both spellings live. Mine.

`present?` instead: blank in a query string means "not specified".

## Severity

Low, and worth stating rather than overselling. `checkFlashSize()` runs on load,
`''` is not in the allowed list, so JavaScript moves off it; and a browser
submits the first option of a select with nothing marked selected. So this never
produced wrong flashing instructions. It rendered a form the visitor had to
notice and correct, reached from a link the site generated itself.

## Verification

`bin/rails test` — 200 runs, 756 assertions, 0 failures (198 before).
Reverting to bare truthiness fails both new tests. 21 rubocop offences in the
touched files, unchanged from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFg9PRy2T6cr983S8gran5