### PR TITLE
Print each chip vendor once, not once per chip

### DIFF
--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -9,7 +9,10 @@ class Vendor < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :urlname, presence: true, uniqueness: true
 
-  scope :soc_vendors, -> { left_joins(:socs).where.not(socs: { id: nil }) }
+  # distinct is load-bearing, not tidiness: the join produces one row per SoC,
+  # so without it the scope yields HiSilicon twenty-three times and the
+  # homepage's vendor strip prints every name once per chip.
+  scope :soc_vendors, -> { left_joins(:socs).where.not(socs: { id: nil }).distinct }
 
   # Rails hands `find` whatever came out of the URL, and `to_param` returns the
   # slug, so a slug has to resolve first; ids still work, for old links and for

--- a/test/controllers/relaunch_pages_test.rb
+++ b/test/controllers/relaunch_pages_test.rb
@@ -209,14 +209,20 @@ class RelaunchPagesTest < ActionDispatch::IntegrationTest
   # makers, and listing those claims silicon we do not run on.
   test 'the silicon strip lists chip vendors, not sensor makers' do
     chipmaker = Vendor.create!(name: 'Teststar Semiconductor')
+    # Two SoCs, because the scope joins them: one row per SoC unless it says
+    # distinct, and a vendor with one chip cannot tell the difference.
     Soc.create!(model: 'TS1234', vendor: chipmaker)
+    Soc.create!(model: 'TS5678', vendor: chipmaker)
     sensor_maker = Vendor.create!(name: 'Testsen Imaging')
 
     get '/'
 
-    assert_includes response.body, chipmaker.name
-    assert_not_includes response.body, sensor_maker.name,
-                        'a vendor with no SoCs is being counted as silicon we run on'
+    names = css_select('.silicon-strip span.text-data').map { |s| s.text.strip }
+
+    assert_includes names, chipmaker.name
+    assert_not_includes names, sensor_maker.name,
+                        'a vendor with no SoCs is being listed as silicon we run on'
+    assert_equal names.uniq, names, 'the strip repeats a vendor once per chip it makes'
   end
 
   # Locale rides in the query string, and redirect('/path') drops it, so a


### PR DESCRIPTION
Reported on dev: the homepage's "Runs on silicon by" strip lists
`HiSilicon` twenty-three times, `Ingenic` twenty-seven, `SigmaStar` thirty.

## Cause

Mine, in #127. The strip used to read `Vendor.order(:name)`, which counted
sensor-only makers as chip vendors. I moved it to the existing
`Vendor.soc_vendors` scope — which is right — but that scope is

```ruby
left_joins(:socs).where.not(socs: { id: nil })
```

one row per **SoC**, not per vendor. So `pluck(:name)` returns a vendor's
name once for every chip it makes.

## Fix

`distinct` on the scope, where the join is. It has exactly one caller, so
there is nothing else to reconcile, and a scope named `soc_vendors` should
mean one row per vendor whoever asks.

## Why the test did not catch it

It asserted which names appeared and never that each appeared **once**, and
its fixture vendor had a single SoC — so it could not have told the
difference. It now creates a vendor with two chips and asserts the rendered
strip has no repeats. Checked against the unfixed scope first:

```
RelaunchPagesTest#test_the_silicon_strip_lists_chip_vendors,_not_sensor_makers
the strip repeats a vendor once per chip it makes.
```

## Verification

| | |
|---|---|
| `bin/rails test` | 314 runs, 1497 assertions, **0 failures** |
| new assertion against unfixed code | fails, on the intended assertion |