### PR TITLE
Point the index at a release that cannot be re-uploaded under it

### DIFF
--- a/app/models/release_cache.rb
+++ b/app/models/release_cache.rb
@@ -112,7 +112,7 @@ class ReleaseCache
       resolve(entry)
     rescue Mismatch => e
       current = lookup
-      raise if same_asset?(current, entry)
+      raise if same_entry?(current, entry)
 
       Rails.logger.info "release cache: #{@name} moved on while we were fetching it (#{e.message}); " \
                         'retrying against the index as it now reads'
@@ -133,11 +133,24 @@ class ReleaseCache
     blob
   end
 
-  # Same file, as far as anything here can tell. `release` is deliberately not
-  # part of it: the same bytes republished under a dated tag are not a reason
-  # to download them again.
-  def same_asset?(one, other)
-    one.bytes.to_i == other.bytes.to_i && one.digest.to_s == other.digest.to_s
+  # The index still saying what it said, in every part of it a fetch depends
+  # on -- the release included, because that is the address, and the same
+  # digest moved to a different one is a different file to go and ask for.
+  #
+  # That case is not hypothetical: pinning rewrites the release of hundreds of
+  # entries while their digests stay exactly as they were, so a request that
+  # mismatched against a rolling tag moments earlier is one whose retry has
+  # somewhere new to look. Comparing content alone would have refused it and
+  # served the older cached image -- the very thing this is here to stop.
+  #
+  # It costs nothing to be liberal here. A retry only reaches the network when
+  # the blob is not already on disk, and blobs are named for their content, so
+  # bytes this cache has seen before are still not downloaded twice however
+  # many releases republish them.
+  def same_entry?(one, other)
+    one.bytes.to_i == other.bytes.to_i &&
+      one.digest.to_s == other.digest.to_s &&
+      one.release.to_s == other.release.to_s
   end
 
   # Nothing that follows trusts @name: it has to be something upstream is

--- a/app/models/release_cache.rb
+++ b/app/models/release_cache.rb
@@ -29,6 +29,12 @@ class ReleaseCache
   class UnknownAsset < StandardError; end
   class Unavailable < StandardError; end
 
+  # The bytes upstream served are not the bytes the index describes. A subclass
+  # of Unavailable, so every caller that already answers for one answers for
+  # this unchanged; separate, so `path` can tell the one failure worth retrying
+  # from a timeout or a refused host.
+  class Mismatch < Unavailable; end
+
   DOWNLOAD_BASE = 'https://github.com/OpenIPC/firmware/releases/download'
 
   # github.com redirects to the CDN, which is a different host, so redirects
@@ -78,17 +84,7 @@ class ReleaseCache
   end
 
   def path
-    entry = lookup
-    blob = File.join(blobs_dir, key_for(entry))
-    return blob if usable?(blob, entry)
-
-    with_lock(entry) do
-      # Whoever held the lock may have been fetching this very blob.
-      return blob if usable?(blob, entry)
-
-      fetch(entry, blob)
-    end
-    blob
+    current_blob
   rescue SystemCallError, IOError => e
     # The cache root is a mount, so it can be absent, root-owned, read-only or
     # full -- and the first of those is exactly what a cutover gets wrong.
@@ -99,6 +95,50 @@ class ReleaseCache
   end
 
   private
+
+  # One retry, and only when the index has moved on underneath us.
+  #
+  # A mismatch says the index is describing a file that is no longer at the
+  # address it names -- which, while entries could point at a rolling tag, was
+  # every download made in the hour after a nightly upload. The publisher now
+  # pins them to dated releases, so what is left is the assets with no dated
+  # copy (the bootloaders in `latest`) and a fetch that straddles the hourly
+  # index run. Re-reading costs a stat, and the second fetch is only reached
+  # when that stat found a different entry, so a genuinely bad download still
+  # fails once rather than twice.
+  def current_blob
+    entry = lookup
+    begin
+      resolve(entry)
+    rescue Mismatch => e
+      current = lookup
+      raise if same_asset?(current, entry)
+
+      Rails.logger.info "release cache: #{@name} moved on while we were fetching it (#{e.message}); " \
+                        'retrying against the index as it now reads'
+      resolve(current)
+    end
+  end
+
+  def resolve(entry)
+    blob = File.join(blobs_dir, key_for(entry))
+    return blob if usable?(blob, entry)
+
+    with_lock(entry) do
+      # Whoever held the lock may have been fetching this very blob.
+      return blob if usable?(blob, entry)
+
+      fetch(entry, blob)
+    end
+    blob
+  end
+
+  # Same file, as far as anything here can tell. `release` is deliberately not
+  # part of it: the same bytes republished under a dated tag are not a reason
+  # to download them again.
+  def same_asset?(one, other)
+    one.bytes.to_i == other.bytes.to_i && one.digest.to_s == other.digest.to_s
+  end
 
   # Nothing that follows trusts @name: it has to be something upstream is
   # publishing before it can become a path or a URL.
@@ -160,12 +200,12 @@ class ReleaseCache
 
   def verify!(entry, tmp, sha)
     actual = File.size(tmp)
-    raise Unavailable, "#{entry.name}: got #{actual} bytes, expected #{entry.bytes}" if actual != entry.bytes.to_i
+    raise Mismatch, "#{entry.name}: got #{actual} bytes, expected #{entry.bytes}" if actual != entry.bytes.to_i
 
     expected = entry.sha256
     return if expected.nil? || sha == expected
 
-    raise Unavailable, "#{entry.name}: sha256 #{sha} does not match #{expected}"
+    raise Mismatch, "#{entry.name}: sha256 #{sha} does not match #{expected}"
   end
 
   def stamp(blob, entry)

--- a/deploy/publish-release-index.rb
+++ b/deploy/publish-release-index.rb
@@ -264,7 +264,7 @@ def newest_assets
       # below: these are Hashie mashes, and checking one object while keeping
       # another is how `asset.size` came to mean the key count.
       tag = release.tag_name.to_s
-      unless tag.match?(/\A[A-Za-z0-9._-]+\z/)
+      unless plain_tag?(tag)
         log "  refusing #{name.inspect}: tag #{tag.inspect} is not a plain tag"
         next
       end
@@ -285,7 +285,107 @@ def newest_assets
          .sort_by { |_, count| -count }
          .each { |family, count| log format('  skipping %d %s* (nothing here reads them)', count, family) }
 
+  pin_to_immutable(chosen, releases)
   chosen
+end
+
+# Tags whose assets are replaced in place. Both name whatever the last build
+# produced, so neither address means the same bytes for longer than a night.
+ROLLING_TAGS = %w[latest nightly].freeze
+
+# How many unpinnable names a run spells out before it just counts them.
+UNPINNED_NAMED = 10
+
+def plain_tag?(tag)
+  tag.match?(/\A[A-Za-z0-9._-]+\z/)
+end
+
+# Move each entry off a rolling tag and onto a release that publishes the very
+# same file and cannot republish it.
+#
+# The index records where an asset lives *and* what it should hash to, and the
+# app refuses bytes that do not match. Against a rolling tag those two are only
+# true together until the next upload: this runs at five past the hour, the
+# nightly re-uploads over it between 18:20 and 19:05 UTC, and in between,
+# `.../download/nightly/openipc.hi3516ev300-nor-lite.tgz` serves a file the
+# index cannot vouch for. Production, 2026-09-12 18:34 UTC:
+#
+#   firmware: serving the cached openipc-hi3516ev300-nor-lite-8mb.bin, its
+#   parts are unavailable: openipc.hi3516ev300-nor-lite.tgz: got 7212740
+#   bytes, expected 7200262
+#
+# -- and the image it served instead was assembled on 09-11 out of the 09-10
+# build, because that is the one already on disk. A visitor downloading during
+# the window gets firmware two nights older than the page offers, and nothing
+# says so.
+#
+# Every nightly is published twice, to the rolling tag and to a dated one
+# (`nightly-20260912-d87dae1`), and for the assets this site reads the two are
+# byte-identical: 112 of 112 openipc.*.tgz on 2026-09-12. Pinning to the dated
+# copy makes the digest an assertion about an address that cannot move, so the
+# only thing left between the index and upstream is the hour it takes this to
+# notice a newer build -- which serves the previous night's firmware, verified,
+# instead of failing and falling back further.
+#
+# Releases arrive newest-first, so the first immutable sighting of a digest is
+# the newest release carrying it, and therefore the last to be pruned upstream.
+# Anything with no immutable twin keeps the tag it had: the bootloaders live
+# only in `latest`, and they are also the twenty-two assets upstream publishes
+# no digest for, so there is nothing to pin them by. ReleaseCache retries those
+# against a re-read index instead.
+def pin_to_immutable(chosen, releases)
+  wanted = rolling_entries(chosen)
+  return if wanted.empty?
+
+  rolling = wanted.size
+  releases.each do |release|
+    tag = release.tag_name.to_s
+    # Silently, unlike the loop above: a tag nothing is pinned to is a tag
+    # nothing is stored from, so there is nothing to report about it.
+    next if ROLLING_TAGS.include?(tag) || !plain_tag?(tag)
+
+    pin_from(release, tag, wanted)
+    break if wanted.empty?
+  end
+  report_pinning(rolling, wanted)
+end
+
+# The entries a rolling tag is all that stands behind. An asset upstream
+# publishes no digest for is not one of them: there is nothing to recognise the
+# same file by, and those twenty-two are the bootloaders, which have not been
+# rebuilt since 2025.
+def rolling_entries(chosen)
+  chosen.each_value.with_object({}) do |asset, map|
+    next unless ROLLING_TAGS.include?(asset[:release])
+    next unless asset[:digest].to_s.start_with?('sha256:')
+
+    map[[asset[:name], asset[:digest]]] = asset
+  end
+end
+
+# Anything this release publishes byte-for-byte, moved onto it. The whole entry
+# follows the digest, timestamp included: it should describe the copy it points
+# at rather than the one that happened to be found first.
+def pin_from(release, tag, wanted)
+  release.assets.each do |asset|
+    entry = wanted.delete([asset['name'], asset['digest']])
+    next if entry.nil?
+
+    entry[:release] = tag
+    entry[:url] = asset['browser_download_url']
+    entry[:updated_at] = asset['updated_at']
+  end
+end
+
+# What is still on a rolling tag is named, because each one is a download that
+# can still be caught mid-upload -- but capped, because the day upstream stops
+# publishing dated nightlies every asset lands here, and an hourly cron mail is
+# not the place for 113 lines of it.
+def report_pinning(rolling, unpinned)
+  log "#{rolling - unpinned.size} of #{rolling} rolling-tag asset(s) pinned to a dated release"
+  left = unpinned.each_value.map { |asset| asset[:name] }.sort
+  left.first(UNPINNED_NAMED).each { |name| log "  no immutable copy of #{name}" }
+  log "  and #{left.size - UNPINNED_NAMED} more" if left.size > UNPINNED_NAMED
 end
 
 # A local file is current when it is both the size and the content the API

--- a/test/models/release_cache_test.rb
+++ b/test/models/release_cache_test.rb
@@ -43,6 +43,22 @@ class ReleaseCacheTest < ActiveSupport::TestCase
     ReleaseIndex.reset!
   end
 
+  # The publisher's hourly run, catching up with a rebuilt asset. No `reset!`
+  # here, unlike write_index: that the file on disk is noticed by itself is
+  # exactly what the retry depends on.
+  def republish(body)
+    File.write(File.join(@index_root, '.index.json'),
+               JSON.generate('generated_at' => '2026-08-24T01:00:00Z',
+                             'assets' => {
+                               'openipc.ts3516ev300-nor-lite.tgz' => {
+                                 'size' => body.bytesize,
+                                 'digest' => "sha256:#{Digest::SHA256.hexdigest(body)}",
+                                 'updated_at' => '2026-08-24T00:30:00Z',
+                                 'release' => 'nightly-20260824-abc1234'
+                               }
+                             }))
+  end
+
   # Stands in for the network. Records every call so a test can prove a fetch
   # did or did not happen.
   def serve(body)
@@ -121,6 +137,38 @@ class ReleaseCacheTest < ActiveSupport::TestCase
     ReleaseCache.downloader = ->(_url, dest) { IO.binwrite(dest, 'short'); Digest::SHA256.hexdigest('short') }
     assert_raises(ReleaseCache::Unavailable) { ReleaseCache.path('u-boot-ts3516ev300-nor.bin') }
     assert_empty Dir.glob(File.join(@cache_root, 'blobs', '*'))
+  end
+
+  # --- an index that has moved on ---
+
+  test 'an asset rebuilt between the index and the fetch is fetched again from the entry that now describes it' do
+    rebuilt = (PAYLOAD * 11).b
+    # Upstream replaced the file, and the publisher's next run lands while the
+    # request is in flight. With entries pointing at a rolling tag this was the
+    # ordinary state of things for the hour after every nightly.
+    ReleaseCache.downloader = lambda { |url, dest|
+      @fetches << url
+      republish(rebuilt) if @fetches.one?
+      IO.binwrite(dest, rebuilt)
+      Digest::SHA256.hexdigest(rebuilt)
+    }
+
+    path = ReleaseCache.path('openipc.ts3516ev300-nor-lite.tgz')
+    assert_equal Digest::SHA256.hexdigest(rebuilt), File.basename(path)
+    assert_equal rebuilt, IO.binread(path)
+    assert_equal 2, @fetches.size
+  end
+
+  test 'a body that does not match an index that has not moved on is refused without fetching twice' do
+    serve('something else entirely'.b * 10)
+    assert_raises(ReleaseCache::Unavailable) { ReleaseCache.path('openipc.ts3516ev300-nor-lite.tgz') }
+    assert_equal 1, @fetches.size
+  end
+
+  test 'a mismatch is an Unavailable, which is what Firmware falls back on' do
+    serve('something else entirely'.b * 10)
+    error = assert_raises(ReleaseCache::Mismatch) { ReleaseCache.path('openipc.ts3516ev300-nor-lite.tgz') }
+    assert_kind_of ReleaseCache::Unavailable, error
   end
 
   test 'a failed fetch leaves no temporary file behind' do

--- a/test/models/release_cache_test.rb
+++ b/test/models/release_cache_test.rb
@@ -43,10 +43,11 @@ class ReleaseCacheTest < ActiveSupport::TestCase
     ReleaseIndex.reset!
   end
 
-  # The publisher's hourly run, catching up with a rebuilt asset. No `reset!`
-  # here, unlike write_index: that the file on disk is noticed by itself is
-  # exactly what the retry depends on.
-  def republish(body)
+  # The publisher's hourly run, catching up with a rebuilt asset or pinning one
+  # to the dated release that publishes it. No `reset!` here, unlike
+  # write_index: that the file on disk is noticed by itself is exactly what the
+  # retry depends on.
+  def republish(body, release: 'nightly-20260824-abc1234')
     File.write(File.join(@index_root, '.index.json'),
                JSON.generate('generated_at' => '2026-08-24T01:00:00Z',
                              'assets' => {
@@ -54,7 +55,7 @@ class ReleaseCacheTest < ActiveSupport::TestCase
                                  'size' => body.bytesize,
                                  'digest' => "sha256:#{Digest::SHA256.hexdigest(body)}",
                                  'updated_at' => '2026-08-24T00:30:00Z',
-                                 'release' => 'nightly-20260824-abc1234'
+                                 'release' => release
                                }
                              }))
   end
@@ -157,6 +158,24 @@ class ReleaseCacheTest < ActiveSupport::TestCase
     assert_equal Digest::SHA256.hexdigest(rebuilt), File.basename(path)
     assert_equal rebuilt, IO.binread(path)
     assert_equal 2, @fetches.size
+  end
+
+  test 'an asset pinned to another release while the fetch was in flight is fetched from the new address' do
+    # The bytes never change here: the rolling tag is mid-upload and serving
+    # something else, and the index run that lands meanwhile pins the entry --
+    # same size, same digest -- to the dated release that still has the file.
+    ReleaseCache.downloader = lambda { |url, dest|
+      @fetches << url
+      republish(PAYLOAD, release: 'nightly-20260824-abc1234') if @fetches.one?
+      body = url.include?('/nightly/') ? 'a half-written upload'.b : PAYLOAD
+      IO.binwrite(dest, body)
+      Digest::SHA256.hexdigest(body)
+    }
+
+    path = ReleaseCache.path('openipc.ts3516ev300-nor-lite.tgz')
+    assert_equal PAYLOAD, IO.binread(path)
+    assert_equal 2, @fetches.size
+    assert_includes @fetches.last, '/nightly-20260824-abc1234/'
   end
 
   test 'a body that does not match an index that has not moved on is refused without fetching twice' do


### PR DESCRIPTION
## The problem

The release index records **where** an asset lives and **what it should hash to**, and `ReleaseCache` refuses bytes that do not match. Against the rolling `nightly` and `latest` tags those two facts are only true together until the next upload: the index is written at five past the hour, upstream re-uploads over it between roughly 18:20 and 19:05 UTC, and in between every download of a rebuilt asset fetches a file the index cannot vouch for.

`Firmware#generate` then serves whatever image is already cached in `public/files`. Caught live on production, 2026-09-12 18:34 UTC:

```
firmware: serving the cached openipc-hi3516ev300-nor-lite-8mb.bin, its parts are unavailable:
openipc.hi3516ev300-nor-lite.tgz: got 7212740 bytes, expected 7200262
```

The image it served instead had been assembled on 09-11 out of the 09-10 build, so a visitor downloading during the window got firmware two nights older than the page offered, and nothing said so. Rare in practice — two events in 172 full-image downloads over five hours — because the window is about an hour a day.

## The fix

Every nightly is published twice, to the rolling tag and to a dated one (`nightly-20260912-d87dae1`), and for the assets this site reads the two copies are byte-identical: 112 of 112 `openipc.*.tgz` on 2026-09-12. `deploy/publish-release-index.rb` now moves each rolling-tag entry onto the dated release publishing the same `(name, digest)`, so the address the app is handed cannot change under it:

```
 openipc.hi3516ev300-nor-lite.tgz   release: nightly                    <- replaced every night
 openipc.hi3516ev300-nor-lite.tgz   release: nightly-20260912-d87dae1   <- same bytes, fixed address
```

What is left is the hour it takes to notice a newer build, which serves the previous night's firmware *verified* rather than falling back further.

`ReleaseCache` answers for the assets that cannot be pinned. A mismatch is now its own error — `Mismatch < Unavailable`, so `Firmware`'s fallback behaviour is unchanged — and it gets one retry: re-read the index, and if it has moved on, fetch again from the entry that describes what upstream is actually serving. If it has not moved on, the bytes are refused exactly as before, without a second download.

## Verification

- **Dry run of the modified publisher on the production host** (writes nothing): `113 of 179 rolling-tag asset(s) pinned to a dated release`, then `dry run, nothing written`. The 66 left are the bootloaders, which only `latest` carries, plus `openipc.hi3518ev201-nor-lite.tgz`; a further 22 assets carry no digest at all and are deliberately not considered.
- **Full suite**: 363 runs, 1841 assertions, 0 failures, 0 errors. Three new tests in `release_cache_test.rb`; the two behaviour tests fail without the change.
- **Rubocop**: 8 / 4 / 38 offences on the three touched files, unchanged from master.

## Deploying

Two halves, and only one rides the image.

- The app half deploys normally.
- The publisher half is the cron script: `/usr/local/sbin/openipc-publish-release-index` is a symlink into the git checkout at `/srv/www/deploy-src`, which needs a pull. `/srv/github-releases` is shared by the dev and prod containers, so there is no dev-only rehearsal for that half — the host dry run above is the rehearsal.